### PR TITLE
Version 0.8.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ DerivedData
 *.hmap
 *.ipa
 
+# AppCode
+.idea
+
 # Bundler
 .bundle
 

--- a/CoreBluetoothMock/Classes/CBMCentralManager.swift
+++ b/CoreBluetoothMock/Classes/CBMCentralManager.swift
@@ -38,7 +38,7 @@ public protocol CBMCentralManager: class {
     var delegate: CBMCentralManagerDelegate? { get set }
     
     /// The current state of the manager, initially set to
-    /// <code>CBManagerStateUnknown</code>. Updates are provided by required delegate
+    /// `CBManagerStateUnknown`. Updates are provided by required delegate
     /// method `centralManagerDidUpdateState(_:)`.
     var state: CBMManagerState { get }
     
@@ -52,16 +52,16 @@ public protocol CBMCentralManager: class {
     static func supports(_ features: CBMCentralManager.Feature) -> Bool
     
     /// Starts scanning for peripherals that are advertising any of the services listed
-    /// in <i>serviceUUIDs</i>. Although strongly discouraged, if <i>serviceUUIDs</i>
-    /// is <i>nil</i> all discovered peripherals will be returned. If the central is
-    /// already scanning with different <i>serviceUUIDs</i> or <i>options</i>, the
+    /// in serviceUUIDs. Although strongly discouraged, if serviceUUIDs
+    /// is nil all discovered peripherals will be returned. If the central is
+    /// already scanning with different serviceUUIDs or options, the
     /// provided parameters will replace them. Applications that have specified the
-    /// <code>bluetooth-central</code> background mode are allowed to scan while
+    /// `bluetooth-central` background mode are allowed to scan while
     /// backgrounded, with two caveats: the scan must specify one or more service types
-    /// in <i>serviceUUIDs</i>, and the <code>CBCentralManagerScanOptionAllowDuplicatesKey</code>
+    /// in serviceUUIDs, and the `CBCentralManagerScanOptionAllowDuplicatesKey`
     /// scan option will be ignored.
     /// - Parameters:
-    ///   - serviceUUIDs: A list of <code>CBUUID</code> objects representing the service(s)
+    ///   - serviceUUIDs: A list of `CBUUID` objects representing the service(s)
     ///                   to scan for.
     ///   - options: An optional dictionary specifying options for the scan.
     func scanForPeripherals(withServices serviceUUIDs: [CBMUUID]?, options: [String : Any]?)
@@ -69,34 +69,34 @@ public protocol CBMCentralManager: class {
     /// Stops scanning for peripherals.
     func stopScan()
     
-    /// Initiates a connection to <i>peripheral</i>. Connection attempts never time out
+    /// Initiates a connection to peripheral. Connection attempts never time out
     /// and, depending on the outcome, will result in a call to either
     /// `centralManager(didConnect:)` or `centralManager(didFailToConnect:error:)`.
-    /// Pending attempts are cancelled automatically upon deallocation of <i>peripheral</i>,
+    /// Pending attempts are cancelled automatically upon deallocation of peripheral,
     /// and explicitly via `cancelPeripheralConnection(_:)`.
     /// - Parameters:
-    ///   - peripheral: The <code>CBMPeripheral</code> to be connected.
+    ///   - peripheral: The `CBMPeripheral` to be connected.
     ///   - options: An optional dictionary specifying connection behavior options.
     func connect(_ peripheral: CBMPeripheral, options: [String : Any]?)
     
-    /// Cancels an active or pending connection to <i>peripheral</i>. Note that this
-    /// is non-blocking, and any <code>CBMPeripheral</code> commands that are still
-    /// pending to <i>peripheral</i> may or may not complete.
-    /// - Parameter peripheral: A <code>CBMPeripheral</code>.
+    /// Cancels an active or pending connection to peripheral. Note that this
+    /// is non-blocking, and any `CBMPeripheral` commands that are still
+    /// pending to peripheral may or may not complete.
+    /// - Parameter peripheral: A `CBMPeripheral`.
     func cancelPeripheralConnection(_ peripheral: CBMPeripheral)
     
-    /// Attempts to retrieve the <code>CBMPeripheral</code> object(s) with the
-    /// corresponding <i>identifiers</i>.
-    /// - Parameter identifiers: A list of <code>UUID</code> objects.
+    /// Attempts to retrieve the `CBMPeripheral` object(s) with the
+    /// corresponding identifiers.
+    /// - Parameter identifiers: A list of `UUID` objects.
     @available(iOS 7.0, *)
     func retrievePeripherals(withIdentifiers identifiers: [UUID]) -> [CBMPeripheral]
     
     /// Retrieves all peripherals that are connected to the system and implement
-    /// any of the services listed in <i>serviceUUIDs</i>.
+    /// any of the services listed in serviceUUIDs.
     /// Note that this set can include peripherals which were connected by other
     /// applications, which will need to be connected locally via
     /// `connect(peripheral:options:)` before they can be used.
-    /// - Returns: A list of <code>CBMPeripheral</code> objects.
+    /// - Returns: A list of `CBMPeripheral` objects.
     @available(iOS 7.0, *)
     func retrieveConnectedPeripherals(withServices serviceUUIDs: [CBMUUID]) -> [CBMPeripheral]
     

--- a/CoreBluetoothMock/Classes/CBMCentralManagerFactory.swift
+++ b/CoreBluetoothMock/Classes/CBMCentralManagerFactory.swift
@@ -54,7 +54,7 @@ public class CBMCentralManagerFactory {
     @available(iOS 13.0, *)
     public static var simulateFeaturesSupport: ((_ features: CBMCentralManager.Feature) -> Bool)?
     
-    /// Returns the implementaton of CBCentralManager, depending on the environment.
+    /// Returns the implementation of CBCentralManager, depending on the environment.
     /// On a simulator, or when the `forceMock` flag is enabled, the mock
     /// implementation is returned, otherwise the native one.
     /// - Parameters:
@@ -70,7 +70,7 @@ public class CBMCentralManagerFactory {
         #endif
     }
     
-    /// Returns the implementaton of CBCentralManager, depending on the environment.
+    /// Returns the implementation of CBCentralManager, depending on the environment.
     /// On a simulator, or when the `forceMock` flag is enabled, the mock
     /// implementation is returned, otherwise the native one.
     /// - Parameters:
@@ -91,7 +91,7 @@ public class CBMCentralManagerFactory {
         #endif
     }
     
-    /// Returns the implementaton of CBCentralManager, depending on the environment.
+    /// Returns the implementation of CBCentralManager, depending on the environment.
     /// On a simulator, or when the `forceMock` flag is enabled, the mock
     /// implementation is returned, otherwise the native one.
     /// - Parameters:

--- a/CoreBluetoothMock/Classes/CBMCentralManagerMock.swift
+++ b/CoreBluetoothMock/Classes/CBMCentralManagerMock.swift
@@ -225,6 +225,10 @@ public class CBMCentralManagerMock: NSObject, CBMCentralManager {
             return
         }
         peripheral.services = newServices
+
+        guard peripheral.virtualConnections > 0 else {
+            return
+        }
         let existingManagers = managers.compactMap { $0.ref }
         existingManagers.forEach { manager in
             manager.peripherals[peripheral.identifier]?
@@ -254,6 +258,9 @@ public class CBMCentralManagerMock: NSObject, CBMCentralManager {
                                     didUpdateValueFor characteristic: CBMCharacteristicMock) {
         // Is the peripheral simulated?
         guard peripherals.contains(peripheral) else {
+            return
+        }
+        guard peripheral.virtualConnections > 0 else {
             return
         }
         managers

--- a/CoreBluetoothMock/Classes/CBMCentralManagerMock.swift
+++ b/CoreBluetoothMock/Classes/CBMCentralManagerMock.swift
@@ -148,7 +148,7 @@ public class CBMCentralManagerMock: NSObject, CBMCentralManager {
     /// Sets the initial state of the Bluetooth central manager.
     ///
     /// This method should only be called ones, before any `CBMCentralManagerMock`
-    /// is created. By defult, the initial state is `.poweredOff`.
+    /// is created. By default, the initial state is `.poweredOff`.
     /// - Parameter state: The initial state of the central manager.
     public static func simulateInitialState(_ state: CBMManagerState) {
         managerState = state
@@ -158,7 +158,7 @@ public class CBMCentralManagerMock: NSObject, CBMCentralManager {
     ///
     /// Peripherals added using this method will be available for scanning
     /// and connecting, depending on their proximity. Use
-    /// periperal's `simulateProximity(of:didChangeTo:)` to modify proximity.
+    /// peripheral's `simulateProximity(of:didChangeTo:)` to modify proximity.
     ///
     /// This method may only be called once, before any manager was created.
     /// - Parameter peripherals: Peripherals that are not connected.
@@ -212,7 +212,7 @@ public class CBMCentralManagerMock: NSObject, CBMCentralManager {
         }
     }
     
-    /// Simulates a sitution when the device changes its services.
+    /// Simulates a situation when the device changes its services.
     /// - Parameters:
     ///   - peripheral: The peripheral that changed services.
     ///   - newName: New device name.
@@ -286,9 +286,9 @@ public class CBMCentralManagerMock: NSObject, CBMCentralManager {
         // TODO: notify a user registered for connection events
     }
     
-    /// Simulates the peripheral to disconenct from the device.
+    /// Simulates the peripheral to disconnect from the device.
     /// All connected mock central managers will receive
-    /// `peripheral(:didDisconencted:error)` callback.
+    /// `peripheral(:didDisconnected:error)` callback.
     /// - Parameter peripheral: The peripheral to disconnect.
     /// - Parameter error: The disconnection reason. Use `CBError` or
     ///                    `CBATTError` errors.
@@ -567,7 +567,7 @@ public class CBMPeripheralMock: CBMPeer, CBMPeripheral {
     private var queue: DispatchQueue {
         return manager.queue
     }
-    /// The mock peripheral with user-defined implementatino.
+    /// The mock peripheral with user-defined implementation.
     private let mock: CBMPeripheralSpec
     /// Size of the outgoing buffer. Only this many packets
     /// can be written without response in a loop, without
@@ -596,7 +596,7 @@ public class CBMPeripheralMock: CBMPeer, CBMPeripheral {
     public var name: String? {
         // If the device wasn't connected and has just been scanned first time,
         // return nil. When scanning continued, the Local Name from the
-        // advertisment data is returned. When the device was connected, the
+        // advertisement data is returned. When the device was connected, the
         // central reads the Device Name characteristic and returns cached value.
         return wasConnected ?
             mock.name :
@@ -846,7 +846,7 @@ public class CBMPeripheralMock: CBMPeer, CBMPeripheral {
                     .filter { s in !service._includedServices!
                         .contains(where: { ds in s.identifier == ds.identifier })
                     }
-                    // Copy the service info, without included characterisitics.
+                    // Copy the service info, without included characteristics.
                     .map { CBMService(shallowCopy: $0, for: self) }
             let newServicesCount = service._includedServices!.count - initialSize
             // Service discovery may takes the more time, the more services
@@ -900,7 +900,7 @@ public class CBMPeripheralMock: CBMPeer, CBMPeripheral {
                 originalCharacteristics
                     // Filter all service characteristics that match given list (if set).
                     .filter { characteristicUUIDs?.contains($0.uuid) ?? true }
-                    // Filter those of them, that are not already in discovered characteritics.
+                    // Filter those of them, that are not already in discovered characteristics.
                     .filter { c in !service._characteristics!
                         .contains(where: { dc in c.identifier == dc.identifier })
                     }

--- a/CoreBluetoothMock/Classes/CBMPeripheralSpec.swift
+++ b/CoreBluetoothMock/Classes/CBMPeripheralSpec.swift
@@ -155,9 +155,10 @@ public class CBMPeripheralSpec {
         CBMCentralManagerMock.peripheral(self, didDisconnectWithError: error)
     }
     
-    /// Simulates a reset of the peripheral. It will make it advertising
-    /// again (if advertising was enabled) immediately. Connected central
-    /// managers will be notified after the supervision timeout is over.
+    /// Simulates a reset of the peripheral. The peripheral will start
+    /// advertising again (if advertising was enabled) immediately.
+    /// Connected central managers will be notified after the supervision
+    /// timeout is over.
     public func simulateReset() {
         simulateDisconnection(withError: CBMError(.connectionTimeout))
     }
@@ -210,8 +211,7 @@ public class CBMPeripheralSpec {
             return
         }
         characteristic.value = data
-        CBMCentralManagerMock.peripheral(self,
-                                        didUpdateValueFor: characteristic)
+        CBMCentralManagerMock.peripheral(self, didUpdateValueFor: characteristic)
     }
     
     public class Builder {
@@ -272,7 +272,7 @@ public class CBMPeripheralSpec {
             return self
         }
         
-        /// Makes the device connnectable, but not connected at the moment
+        /// Makes the device connectable, but not connected at the moment
         /// of initialization.
         /// - Parameters:
         ///   - name: The device name, returned by Device Name characteristic.
@@ -299,7 +299,7 @@ public class CBMPeripheralSpec {
             return self
         }
         
-        /// Makes the device connnectable, and also marks already connected
+        /// Makes the device connectable, and also marks already connected
         /// by some other application. Such device, if not advertising,
         /// can be obtained using `retrieveConnectedPeripherals(withServices:)`.
         /// - Parameters:

--- a/CoreBluetoothMock/Classes/CBMPeripheralSpec.swift
+++ b/CoreBluetoothMock/Classes/CBMPeripheralSpec.swift
@@ -160,6 +160,7 @@ public class CBMPeripheralSpec {
     /// Connected central managers will be notified after the supervision
     /// timeout is over.
     public func simulateReset() {
+        connectionDelegate?.reset()
         simulateDisconnection(withError: CBMError(.connectionTimeout))
     }
     

--- a/CoreBluetoothMock/Classes/CBMPeripheralSpecDelegate.swift
+++ b/CoreBluetoothMock/Classes/CBMPeripheralSpecDelegate.swift
@@ -31,52 +31,142 @@
 import CoreBluetooth
 
 public protocol CBMPeripheralSpecDelegate {
-    
+
+    /// This method will be called when a connect request was initiated from a
+    /// mock central manager.
+    /// - Parameter peripheral: The peripheral specification to handle connection.
+    /// - Returns: Success or an error. The error will be returned using
+    ///            `centralManager(:didFailToConnect:error:)`.
     func peripheralDidReceiveConnectionRequest(_ peripheral: CBMPeripheralSpec)
         -> Result<Void, Error>
-    
+
+    /// This method will be called when disconnection was initiated from a
+    /// mock central manager or peripheral side.
+    /// - Parameters:
+    ///   - peripheral: The peripheral specification that is disconnected.
+    ///   - error: An optional reason of disconnection, in case it was initiated
+    ///            from the peripheral side.
     func peripheral(_ peripheral: CBMPeripheralSpec, didDisconnect error: Error?)
-    
+
+    /// This method will be called when service discovery was initiated using a
+    /// mock central manager. When success is returned, the services will be
+    /// returned automatically based on the device specification.
+    /// - Parameters:
+    ///   - peripheral: The target device.
+    ///   - serviceUUIDs: Optional services requested.
+    /// - Returns: Success, or a service discovery error. The error will be reported
+    ///            using `peripheral(:didDiscoverServices:)`.
     func peripheral(_ peripheral: CBMPeripheralSpec,
                     didReceiveServiceDiscoveryRequest serviceUUIDs: [CBMUUID]?)
         -> Result<Void, Error>
-    
+
+    /// This method will be called when service discovery of included services was
+    /// initiated using a mock central manager. When success is returned, the services
+    /// will be returned automatically based on the device specification.
+    /// - Parameters:
+    ///   - peripheral: The target device.
+    ///   - serviceUUIDs: Optional services requested.
+    ///   - service: The primary service.
+    /// - Returns: Success, or a service discovery error. The error will be reported
+    ///            using `peripheral(:didDiscoverIncludedServices:)`.
     func peripheral(_ peripheral: CBMPeripheralSpec,
                     didReceiveIncludedServiceDiscoveryRequest serviceUUIDs: [CBMUUID]?,
                     for service: CBMService)
         -> Result<Void, Error>
-        
+
+    /// This method will be called when characteristic discovery was initiated using a
+    /// mock central manager. When success is returned, the characteristics will be returned
+    /// automatically based on the device specification.
+    /// - Parameters:
+    ///   - peripheral: The target device.
+    ///   - characteristicUUIDs: Optional characteristics requested.
+    ///   - service: The parent service.
+    /// - Returns: Success, or a service discovery error. The error will be reported
+    ///            using `peripheral(:didDiscoverCharacteristics:)`.
     func peripheral(_ peripheral: CBMPeripheralSpec,
                     didReceiveCharacteristicsDiscoveryRequest characteristicUUIDs: [CBMUUID]?,
                     for service: CBMService)
         -> Result<Void, Error>
-            
+
+    /// This method will be called when descriptor discovery was initiated using a
+    /// mock central manager. When success is returned, the descriptors will be returned
+    /// automatically based on the device specification.
+    /// - Parameters:
+    ///   - peripheral: The target device.
+    ///   - characteristic: The parent characteristic.
+    /// - Returns: Success, or a service discovery error. The error will be reported
+    ///            using `peripheral(:didDiscoverDescriptors:)`.
     func peripheral(_ peripheral: CBMPeripheralSpec,
                     didReceiveDescriptorsDiscoveryRequestFor characteristic: CBMCharacteristic)
         -> Result<Void, Error>
-    
+
+    /// This method will be called when read request has been initiated from a mock
+    /// central manager.
+    /// - Parameters:
+    ///   - peripheral: The target peripheral specification.
+    ///   - characteristic: The characteristic, which value should be returned.
+    /// - Returns: When success, the characteristic value should be returned. In case
+    ///            of a failure, the returned error will be returned to the
+    ///            `peripheral(:didUpdateValueFor:error:)`.
     func peripheral(_ peripheral: CBMPeripheralSpec,
                     didReceiveReadRequestFor characteristic: CBMCharacteristic)
         -> Result<Data, Error>
-    
+
+    /// This method will be called when read request has been initiated from a mock
+    /// central manager.
+    /// - Parameters:
+    ///   - peripheral: The target peripheral specification.
+    ///   - descriptor: The descriptor, which value should be returned.
+    /// - Returns: When success, the descriptor value should be returned. In case
+    ///            of a failure, the returned error will be returned to the
+    ///            `peripheral(:didUpdateValueFor:error:)`.
     func peripheral(_ peripheral: CBMPeripheralSpec,
                     didReceiveReadRequestFor descriptor: CBMDescriptor)
         -> Result<Data, Error>
-    
+
+    /// This method will be called when write request has been initiated from a mock
+    /// central manager.
+    /// - Parameters:
+    ///   - peripheral: The target peripheral specification.
+    ///   - characteristic: The target characteristic.
+    ///   - data: The data written.
+    /// - Returns: Success, or the reason of failure. The returned error will be
+    ///            returned to the `peripheral(:didWriteValueFor:error:)`.
     func peripheral(_ peripheral: CBMPeripheralSpec,
                     didReceiveWriteRequestFor characteristic: CBMCharacteristic,
                     data: Data)
         -> Result<Void, Error>
-    
+
+    /// This method will be called when write command has been initiated from a mock
+    /// central manager. Write command is also known as write without response.
+    /// - Parameters:
+    ///   - peripheral: The target peripheral specification.
+    ///   - characteristic: The target characteristic.
+    ///   - data: The data written.
     func peripheral(_ peripheral: CBMPeripheralSpec,
                     didReceiveWriteCommandFor characteristic: CBMCharacteristic,
                     data: Data)
-    
+
+    /// This method will be called when write request has been initiated from a mock
+    /// central manager.
+    /// - Parameters:
+    ///   - peripheral: The target peripheral specification.
+    ///   - descriptor: The target descriptor.
+    ///   - data: The data written.
+    /// - Returns: Success, or the reason of failure. The returned error will be
+    ///            returned to the `peripheral(:didWriteValueFor:error:)`.
     func peripheral(_ peripheral: CBMPeripheralSpec,
                     didReceiveWriteRequestFor descriptor: CBMDescriptor,
                     data: Data)
         -> Result<Void, Error>
-    
+
+    /// This method will be called when notifications or indications were enabled
+    /// or disabled on the given characteristic using a mock central manager.
+    /// - Parameters:
+    ///   - peripheral: The target peripheral specification.
+    ///   - enabled: Whether notifications or indications were enabled or disabled.
+    ///   - characteristic: The target characteristic.
+    /// - Returns: Success, or the reason of a failure.
     func peripheral(_ peripheral: CBMPeripheralSpec,
                     didReceiveSetNotifyRequest enabled: Bool,
                     for characteristic: CBMCharacteristic)
@@ -91,7 +181,6 @@ public extension CBMPeripheralSpecDelegate {
     }
     
     func peripheral(_ peripheral: CBMPeripheralSpec, didDisconnect error: Error?) {
-        // Empty default implementation
         assert(peripheral.virtualConnections == 0)
     }
     

--- a/CoreBluetoothMock/Classes/CBMPeripheralSpecDelegate.swift
+++ b/CoreBluetoothMock/Classes/CBMPeripheralSpecDelegate.swift
@@ -32,6 +32,10 @@ import CoreBluetooth
 
 public protocol CBMPeripheralSpecDelegate {
 
+    /// This method is called when the mock peripheral has been reset.
+    /// It should reset all values to the initial state.
+    func reset()
+
     /// This method will be called when a connect request was initiated from a
     /// mock central manager.
     /// - Parameter peripheral: The peripheral specification to handle connection.
@@ -174,7 +178,11 @@ public protocol CBMPeripheralSpecDelegate {
 }
 
 public extension CBMPeripheralSpecDelegate {
-    
+
+    func reset() {
+        // Empty default implementation
+    }
+
     func peripheralDidReceiveConnectionRequest(_ peripheral: CBMPeripheralSpec)
         -> Result<Void, Error> {
             return .success(())

--- a/Example/Tests/EventInterceptor.swift
+++ b/Example/Tests/EventInterceptor.swift
@@ -28,28 +28,31 @@
 * POSSIBILITY OF SUCH DAMAGE.
 */
 
-import XCTest
-import CoreBluetoothMock
+import Foundation
+@testable import nRF_Blinky
 
-class Tests: XCTestCase {
+class Sim {
 
-    override func setUp() {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+    static func post(_ notification: Notification) {
+        NotificationCenter.default.post(notification)
     }
 
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    static func dispose(_ observer: NSObjectProtocol) {
+        NotificationCenter.default.removeObserver(observer)
     }
 
-    func testExample() {
-        // This is an example of a functional test case.
-        XCTAssert(true, "Pass")
+    private static func on(_ name: Notification.Name, do action: @escaping (Notification) -> ()) -> NSObjectProtocol {
+        return NotificationCenter.default.addObserver(forName: name, object: nil, queue: nil, using: action)
     }
 
-    func testPerformanceExample() {
-        // This is an example of a performance test case.
-        measure {
-            // Put the code you want to measure the time of here.
+    static func onBlinkyDiscovery(do action: @escaping (BlinkyPeripheral) -> ()) {
+        var observer: NSObjectProtocol?
+        observer = on(.newPeripheral) { notification in
+            if let userInfo = notification.userInfo,
+               let blinky = userInfo["blinky"] as? BlinkyPeripheral {
+                action(blinky)
+            }
+            dispose(observer!)
         }
     }
 

--- a/Example/Tests/NormalBehaviorTest.swift
+++ b/Example/Tests/NormalBehaviorTest.swift
@@ -1,0 +1,135 @@
+/*
+* Copyright (c) 2020, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import XCTest
+@testable import nRF_Blinky
+@testable import CoreBluetoothMock
+
+class NormalBehaviorTest: XCTestCase {
+
+    override func setUp() {
+        (UIApplication.shared.delegate as! AppDelegate).mockingEnabled = true
+        CBMCentralManagerMock.simulatePeripherals([blinky, hrm, thingy])
+        CBMCentralManagerMock.simulateInitialState(.poweredOn)
+    }
+
+    override func tearDown() {
+        CBMCentralManagerMock.simulatePowerOff()
+    }
+
+    func testScanningBlinky() {
+        // Set up the devices in range.
+        blinky.simulateProximityChange(.immediate)
+        hrm.simulateProximityChange(.near)
+        thingy.simulateProximityChange(.far)
+        // Reset the blinky.
+        blinky.simulateReset()
+
+        // Wait until the blinky is found.
+        var target: BlinkyPeripheral?
+        let found = XCTestExpectation(description: "Device found")
+        Sim.onBlinkyDiscovery { blinky in
+            XCTAssertEqual(blinky.advertisedName, "nRF Blinky")
+            XCTAssert(blinky.isConnectable == true)
+            XCTAssert(blinky.isConnected == false)
+            XCTAssertGreaterThanOrEqual(blinky.RSSI.intValue, -70 - 15)
+            XCTAssertLessThanOrEqual(blinky.RSSI.intValue, -70 + 15)
+            target = blinky
+            found.fulfill()
+        }
+        wait(for: [found], timeout: 3)
+        XCTAssertNotNil(target)
+
+        // Select found device.
+        Sim.post(.selectPeripheral(at: 0))
+
+        // Wait until blinky is connected and ready.
+        let connected = XCTestExpectation(description: "Connected")
+        let ready = XCTestExpectation(description: "Ready")
+        target!.onConnected {
+            connected.fulfill()
+        }
+        target!.onReady { ledSupported, buttonSupported in
+            if ledSupported && buttonSupported {
+                ready.fulfill()
+            }
+        }
+        wait(for: [connected, ready], timeout: 3)
+
+        let appDelegate = UIApplication.shared.delegate as! AppDelegate
+        let navigationController = appDelegate.window!.rootViewController as! UINavigationController
+        let blinkyViewController = navigationController.topViewController as! BlinkyViewController
+
+        // Initially, after reset, LED is OFF and button is released.
+
+        // Enable LED by simulating toggling the switch.
+        // The `onLedStateDidChange` handler will be called after the initial state has been read.
+        let ledEnabled = XCTestExpectation(description: "LED Enabled")
+        let ledObserver = target!.onLedStateDidChange { isOn in
+            if isOn {
+                ledEnabled.fulfill()
+            } else {
+                // Simulate toggling the switch.
+                blinkyViewController.ledToggleSwitch.setOn(true, animated: true)
+                blinkyViewController.ledToggleSwitchDidChange(blinkyViewController.ledToggleSwitch)
+            }
+        }
+        wait(for: [ledEnabled], timeout: 6)
+        Sim.dispose(ledObserver)
+
+        // Simulate 2 notifications.
+        let buttonPressed = XCTestExpectation(description: "Button pressed")
+        let buttonReleased = XCTestExpectation(description: "Button released")
+        let buttonObserver = target!.onButtonStateDidChange { isPressed in
+            if isPressed {
+                // Simulate releasing the BTN1 on DK.
+                blinky.simulateValueUpdate(Data([0x00]), for: .buttonCharacteristic)
+                buttonPressed.fulfill()
+            } else {
+                buttonReleased.fulfill()
+            }
+        }
+        // Simulate clicking the BTN1 on DK.
+        blinky.simulateValueUpdate(Data([0x01]), for: .buttonCharacteristic)
+        wait(for: [buttonPressed, buttonReleased], timeout: 1)
+        Sim.dispose(buttonObserver)
+
+        // Simulate graceful disconnect.
+        let disconnection = XCTestExpectation(description: "Disconnection")
+        target!.onDisconnected {
+            disconnection.fulfill()
+        }
+        blinky.simulateDisconnection()
+        wait(for: [disconnection], timeout: 1)
+
+        navigationController.popViewController(animated: true)
+    }
+
+}

--- a/Example/Tests/ResetTest.swift
+++ b/Example/Tests/ResetTest.swift
@@ -1,0 +1,123 @@
+/*
+* Copyright (c) 2020, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import XCTest
+@testable import nRF_Blinky
+@testable import CoreBluetoothMock
+
+class ResetTest: XCTestCase {
+
+    override func setUp() {
+        (UIApplication.shared.delegate as! AppDelegate).mockingEnabled = true
+        CBMCentralManagerMock.simulatePeripherals([blinky, hrm, thingy])
+        CBMCentralManagerMock.simulatePowerOn()
+    }
+
+    override func tearDown() {
+        CBMCentralManagerMock.simulatePowerOff()
+    }
+
+    func testScanningBlinky() {
+        // Set up the devices in range.
+        blinky.simulateProximityChange(.far)
+        hrm.simulateProximityChange(.near)
+        thingy.simulateProximityChange(.far)
+        // Reset the blinky.
+        blinky.simulateReset()
+
+        // Wait until the blinky is found.
+        var target: BlinkyPeripheral?
+        let found = XCTestExpectation(description: "Device found")
+        Sim.onBlinkyDiscovery { blinky in
+            XCTAssertEqual(blinky.advertisedName, "nRF Blinky")
+            XCTAssert(blinky.isConnectable == true)
+            XCTAssert(blinky.isConnected == false)
+            XCTAssertGreaterThanOrEqual(blinky.RSSI.intValue, -100 - 15)
+            XCTAssertLessThanOrEqual(blinky.RSSI.intValue, -100 + 15)
+            target = blinky
+            found.fulfill()
+        }
+        wait(for: [found], timeout: 3)
+        XCTAssertNotNil(target)
+
+        // Select found device.
+        Sim.post(.selectPeripheral(at: 0))
+
+        // Wait until blinky is connected and ready.
+        let connected = XCTestExpectation(description: "Connected")
+        let ready = XCTestExpectation(description: "Ready")
+        target!.onConnected {
+            connected.fulfill()
+        }
+        target!.onReady { ledSupported, buttonSupported in
+            if ledSupported && buttonSupported {
+                ready.fulfill()
+            }
+        }
+        wait(for: [connected, ready], timeout: 3)
+
+        let appDelegate = UIApplication.shared.delegate as! AppDelegate
+        let navigationController = appDelegate.window!.rootViewController as! UINavigationController
+
+        // Initially, LED is OFF and button is released.
+        let ledDisabled = XCTestExpectation(description: "LED Disabled")
+        let buttonReleased = XCTestExpectation(description: "Button released")
+        let buttonPressed = XCTestExpectation(description: "Button pressed")
+        buttonPressed.isInverted = true
+
+        let ledObserver = target!.onLedStateDidChange { isOn in
+            if !isOn {
+                ledDisabled.fulfill()
+            }
+        }
+        let buttonObserver = target!.onButtonStateDidChange { isPressed in
+            if isPressed {
+                buttonPressed.fulfill()
+            } else {
+                buttonReleased.fulfill()
+            }
+        }
+        wait(for: [ledDisabled, buttonReleased], timeout: 1)
+
+        // Simulate reset and button press afterwards.
+        let reset = XCTestExpectation(description: "Reset")
+        target!.onDisconnected {
+            reset.fulfill()
+        }
+        blinky.simulateReset()
+        blinky.simulateValueUpdate(Data([0x01]), for: .buttonCharacteristic)
+        wait(for: [reset, buttonPressed], timeout: 5)
+
+        Sim.dispose(ledObserver)
+        Sim.dispose(buttonObserver)
+        navigationController.popViewController(animated: true)
+    }
+
+}

--- a/Example/UI Tests/UITests.swift
+++ b/Example/UI Tests/UITests.swift
@@ -30,7 +30,7 @@
 
 import XCTest
 
-class nRFBlinky_UITests: XCTestCase {
+class UITests: XCTestCase {
 
     override func setUp() {
         continueAfterFailure = false
@@ -67,9 +67,6 @@ class nRFBlinky_UITests: XCTestCase {
         ledSwitch.tap()
         XCTAssert(ledSwitch.isOn == true)
         XCTAssertEqual(ledState.label, "ON")
-        
-        // A button notification should also be received at this time.
-        XCTAssertEqual(buttonState.label, "PRESSED")
         
         // Tap the LED switch again to disable it.
         ledSwitch.tap()

--- a/Example/nRFBlinky.xcodeproj/project.pbxproj
+++ b/Example/nRFBlinky.xcodeproj/project.pbxproj
@@ -8,11 +8,14 @@
 
 /* Begin PBXBuildFile section */
 		12EB792A927B7E76694CFCA4 /* libPods-nRFBlinky_UITests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B8485F486EB17AEF8380FD7F /* libPods-nRFBlinky_UITests.a */; };
+		2DBB24A841D22CDDB14787B6 /* BlinkyPeripheralEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DBB2D0A6C475A3BA45D6FAA /* BlinkyPeripheralEvents.swift */; };
+		2DBB258568F7E07E0DFA3B4E /* EventInterceptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DBB2F5ACA6DCE530B0DDE90 /* EventInterceptor.swift */; };
+		2DBB2A694C3D00999D8B3E29 /* BlinkyManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DBB27B357E95965525A70A5 /* BlinkyManager.swift */; };
+		2DBB2D9D87AA009D95C10DEE /* ResetTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DBB22CFA82E35CBA3BB326F /* ResetTest.swift */; };
+		2DBB2F44478EB7F4C0DF3AA4 /* BlinkyManagerEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DBB27ABD18F3DAECC075CF2 /* BlinkyManagerEvents.swift */; };
 		443C46A99211A546CF53A0AF /* libPods-nRFBlinky.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2ECFACC911DF92A82403558A /* libPods-nRFBlinky.a */; };
-		526EA530240D1B9000BF70B2 /* (null) in Resources */ = {isa = PBXBuildFile; };
-		526EA531240D1B9000BF70B2 /* (null) in Resources */ = {isa = PBXBuildFile; };
 		526EA53D240D2F8100BF70B2 /* UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526EA53C240D2F8100BF70B2 /* UITests.swift */; };
-		52A648F1240E83F000817F2F /* Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A648F0240E83F000817F2F /* Tests.swift */; };
+		52A648F1240E83F000817F2F /* NormalBehaviorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A648F0240E83F000817F2F /* NormalBehaviorTest.swift */; };
 		52A648F9240E95F700817F2F /* MockPeripherals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B537D723FC129400372948 /* MockPeripherals.swift */; };
 		52A648FB24125D1D00817F2F /* CoreBluetoothTypeAliases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A648FA24125D1D00817F2F /* CoreBluetoothTypeAliases.swift */; };
 		52B537A423FBE84900372948 /* String+Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B5377023FBE84900372948 /* String+Localization.swift */; };
@@ -50,6 +53,11 @@
 
 /* Begin PBXFileReference section */
 		27F0E3EA0E43FEDD6E5988F6 /* libPods-nRFBlinky_Tests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-nRFBlinky_Tests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		2DBB22CFA82E35CBA3BB326F /* ResetTest.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResetTest.swift; sourceTree = "<group>"; };
+		2DBB27ABD18F3DAECC075CF2 /* BlinkyManagerEvents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlinkyManagerEvents.swift; sourceTree = "<group>"; };
+		2DBB27B357E95965525A70A5 /* BlinkyManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlinkyManager.swift; sourceTree = "<group>"; };
+		2DBB2D0A6C475A3BA45D6FAA /* BlinkyPeripheralEvents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlinkyPeripheralEvents.swift; sourceTree = "<group>"; };
+		2DBB2F5ACA6DCE530B0DDE90 /* EventInterceptor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventInterceptor.swift; sourceTree = "<group>"; };
 		2ECFACC911DF92A82403558A /* libPods-nRFBlinky.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-nRFBlinky.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		453BB604F04AB8D6B8030CE1 /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		526EA53A240D2F8100BF70B2 /* nRFBlinky_UITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = nRFBlinky_UITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -57,7 +65,7 @@
 		526EA53E240D2F8100BF70B2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		52A648E0240E7BDF00817F2F /* CoreBluetoothMock.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = CoreBluetoothMock.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		52A648EE240E83F000817F2F /* nRFBlinky_Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = nRFBlinky_Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		52A648F0240E83F000817F2F /* Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tests.swift; sourceTree = "<group>"; };
+		52A648F0240E83F000817F2F /* NormalBehaviorTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NormalBehaviorTest.swift; sourceTree = "<group>"; };
 		52A648F2240E83F000817F2F /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		52A648FA24125D1D00817F2F /* CoreBluetoothTypeAliases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreBluetoothTypeAliases.swift; sourceTree = "<group>"; };
 		52B5377023FBE84900372948 /* String+Localization.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Localization.swift"; sourceTree = "<group>"; };
@@ -165,8 +173,10 @@
 		52A648EF240E83F000817F2F /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				52A648F0240E83F000817F2F /* Tests.swift */,
+				52A648F0240E83F000817F2F /* NormalBehaviorTest.swift */,
 				52A648F8240E844700817F2F /* Supporting Files */,
+				2DBB2F5ACA6DCE530B0DDE90 /* EventInterceptor.swift */,
+				2DBB22CFA82E35CBA3BB326F /* ResetTest.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -192,6 +202,9 @@
 			isa = PBXGroup;
 			children = (
 				52B5377423FBE84900372948 /* BlinkyPeripheral.swift */,
+				2DBB27B357E95965525A70A5 /* BlinkyManager.swift */,
+				2DBB27ABD18F3DAECC075CF2 /* BlinkyManagerEvents.swift */,
+				2DBB2D0A6C475A3BA45D6FAA /* BlinkyPeripheralEvents.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -458,11 +471,9 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				526EA531240D1B9000BF70B2 /* (null) in Resources */,
 				607FACDD1AFB9204008FA782 /* Images.xcassets in Resources */,
 				52B537B023FBE84900372948 /* Main.storyboard in Resources */,
 				52B537AF23FBE84900372948 /* LaunchScreen.storyboard in Resources */,
-				526EA530240D1B9000BF70B2 /* (null) in Resources */,
 				52B537AE23FBE84900372948 /* Localizable.strings in Resources */,
 				52B537AD23FBE84900372948 /* Main.strings in Resources */,
 			);
@@ -552,7 +563,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				52A648F1240E83F000817F2F /* Tests.swift in Sources */,
+				52A648F1240E83F000817F2F /* NormalBehaviorTest.swift in Sources */,
+				2DBB258568F7E07E0DFA3B4E /* EventInterceptor.swift in Sources */,
+				2DBB2D9D87AA009D95C10DEE /* ResetTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -570,6 +583,9 @@
 				52A648FB24125D1D00817F2F /* CoreBluetoothTypeAliases.swift in Sources */,
 				52B537AB23FBE84900372948 /* RootViewController.swift in Sources */,
 				52B537B223FBE85100372948 /* AppDelegate.swift in Sources */,
+				2DBB2A694C3D00999D8B3E29 /* BlinkyManager.swift in Sources */,
+				2DBB2F44478EB7F4C0DF3AA4 /* BlinkyManagerEvents.swift in Sources */,
+				2DBB24A841D22CDDB14787B6 /* BlinkyPeripheralEvents.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/nRFBlinky/AppDelegate.swift
+++ b/Example/nRFBlinky/AppDelegate.swift
@@ -41,6 +41,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     func application(_ application: UIApplication,
                      didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // UI Tests can't access app code, so the Blinky mock must be in the app.
+        // The "mocking-enabled" argument is set in UITests.
         #if DEBUG
         if CommandLine.arguments.contains("mocking-enabled") {
             mockingEnabled = true
@@ -54,6 +56,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
             CBMCentralManagerMock.simulateInitialState(.poweredOn)
             CBMCentralManagerMock.simulatePeripherals([blinky, hrm, thingy])
+
+            // Set up initial conditions.
+            blinky.simulateProximityChange(.immediate)
+            hrm.simulateProximityChange(.near)
+            thingy.simulateProximityChange(.far)
+            blinky.simulateReset()
         }
         #endif
         

--- a/Example/nRFBlinky/Models/BlinkyManager.swift
+++ b/Example/nRFBlinky/Models/BlinkyManager.swift
@@ -1,0 +1,163 @@
+/*
+* Copyright (c) 2020, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+class BlinkyManager {
+    /// Underlying central manager.
+    private var centralManager: CBCentralManager!
+    /// A list of discovered peripherals.
+    private(set) var discoveredPeripherals: [BlinkyPeripheral]
+    /// The blinky peripheral that this manager is currently connecting or connected to.
+    private var connectedBlinky: BlinkyPeripheral?
+
+    var state: CBManagerState {
+        return centralManager.state
+    }
+
+    init(_ mock: Bool) {
+        discoveredPeripherals = []
+        centralManager = CBCentralManagerFactory.instance(
+                delegate: self,
+                queue: nil,
+                options: [CBCentralManagerOptionShowPowerAlertKey : true],
+                forceMock: mock
+        )
+    }
+
+    func startScan() -> Bool {
+        guard centralManager.state == .poweredOn else {
+            return false
+        }
+        if !centralManager.isScanning {
+            centralManager.scanForPeripherals(
+                    withServices: [BlinkyPeripheral.nordicBlinkyServiceUUID],
+                    options: [CBCentralManagerScanOptionAllowDuplicatesKey : true]
+            )
+        }
+        return true
+    }
+
+    func stopScan() {
+        centralManager.stopScan()
+    }
+
+    func reset() {
+        discoveredPeripherals.removeAll()
+    }
+
+    var isEmpty: Bool {
+        return discoveredPeripherals.isEmpty
+    }
+
+    /// Connects to the Blinky device.
+    func connect(_ blinky: BlinkyPeripheral) {
+        guard state == .poweredOn, connectedBlinky == nil else {
+            return
+        }
+        connectedBlinky = blinky
+        print("Connecting to Blinky device...")
+        centralManager.connect(blinky.basePeripheral, options: nil)
+    }
+
+    /// Cancels existing or pending connection.
+    func disconnect(_ blinky: BlinkyPeripheral) {
+        guard state == .poweredOn else {
+            return
+        }
+        guard blinky.state != .disconnected else {
+            return
+        }
+        print("Cancelling connection...")
+        centralManager.cancelPeripheralConnection(blinky.basePeripheral)
+    }
+
+}
+
+extension BlinkyManager: CBCentralManagerDelegate {
+
+    func centralManagerDidUpdateState(_ central: CBCentralManager) {
+        print("Central Manager state changed to \(central.state)")
+        if central.state != .poweredOn {
+            connectedBlinky = nil
+        }
+        post(.manager(self, didChangeStateTo: central.state))
+    }
+
+    func centralManager(_ central: CBCentralManager,
+                        didDiscover peripheral: CBPeripheral,
+                        advertisementData: [String : Any],
+                        rssi RSSI: NSNumber) {
+        let blinky = BlinkyPeripheral(
+                withPeripheral: peripheral,
+                advertisementData: advertisementData,
+                andRSSI: RSSI,
+                using: self
+        )
+        if !discoveredPeripherals.contains(blinky) {
+            discoveredPeripherals.append(blinky)
+        }
+        post(.manager(self, didDiscover: blinky))
+    }
+
+    public func centralManager(_ central: CBCentralManager,
+                               didConnect peripheral: CBPeripheral) {
+        if let blinky = connectedBlinky,
+           blinky.basePeripheral.identifier == peripheral.identifier {
+            print("Blinky connected")
+            blinky.post(.blinkyDidConnect(blinky))
+        }
+    }
+
+    public func centralManager(_ central: CBCentralManager,
+                               didFailToConnect peripheral: CBPeripheral,
+                               error: Error?) {
+        if let blinky = connectedBlinky,
+           blinky.basePeripheral.identifier == peripheral.identifier {
+            if let error = error {
+                print("Connection failed: \(error)")
+            } else {
+                print("Connection failed: No error")
+            }
+            blinky.post(.blinkyDidDisconnect(blinky))
+        }
+    }
+
+    public func centralManager(_ central: CBCentralManager,
+                               didDisconnectPeripheral peripheral: CBPeripheral,
+                               error: Error?) {
+        if let blinky = connectedBlinky,
+           blinky.basePeripheral.identifier == peripheral.identifier {
+            print("Blinky disconnected")
+            connectedBlinky = nil
+            blinky.post(.blinkyDidDisconnect(blinky))
+        }
+    }
+}

--- a/Example/nRFBlinky/Models/BlinkyManagerEvents.swift
+++ b/Example/nRFBlinky/Models/BlinkyManagerEvents.swift
@@ -1,0 +1,86 @@
+/*
+* Copyright (c) 2020, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+import CoreBluetoothMock
+
+extension Notification.Name {
+
+    static let newPeripheral = Notification.Name("New Peripheral")
+    static let state         = Notification.Name("Central Manager State")
+
+}
+
+extension Notification {
+
+    static func manager(_ manager: BlinkyManager, didDiscover blinky: BlinkyPeripheral) -> Notification {
+        return Notification(name: .newPeripheral,
+                            userInfo: ["blinky": blinky])
+    }
+
+    static func manager(_ manager: BlinkyManager, didChangeStateTo state: CBMManagerState) -> Notification {
+        return Notification(name: .state, userInfo: ["state": state])
+    }
+
+}
+
+extension BlinkyManager {
+
+    func post(_ notification: Notification) {
+        NotificationCenter.default.post(notification)
+    }
+
+    func dispose(_ observer: NSObjectProtocol) {
+        NotificationCenter.default.removeObserver(observer)
+    }
+
+    private func on(_ name: Notification.Name, do action: @escaping (Notification) -> ()) -> NSObjectProtocol {
+        return NotificationCenter.default.addObserver(forName: name, object: nil, queue: nil, using: action)
+    }
+
+    func onBlinkyDiscovery(do action: @escaping (BlinkyPeripheral) -> ()) -> NSObjectProtocol {
+        return on(.newPeripheral) { notification in
+            if let userInfo = notification.userInfo,
+               let blinky = userInfo["blinky"] as? BlinkyPeripheral {
+                action(blinky)
+            }
+        }
+    }
+
+    func onStateChange(do action: @escaping (CBMManagerState) -> ()) -> NSObjectProtocol {
+        return on(.state) { notification in
+            if let userInfo = notification.userInfo,
+               let state = userInfo["state"] as? CBMManagerState {
+                action(state)
+            }
+        }
+    }
+
+}

--- a/Example/nRFBlinky/Models/BlinkyPeripheralEvents.swift
+++ b/Example/nRFBlinky/Models/BlinkyPeripheralEvents.swift
@@ -1,0 +1,131 @@
+/*
+* Copyright (c) 2020, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+extension Notification.Name {
+
+    static let connection    = Notification.Name("Connection")
+    static let ready         = Notification.Name("Ready")
+    static let disconnection = Notification.Name("Disconnection")
+    static let ledState      = Notification.Name("LED State")
+    static let buttonState   = Notification.Name("Button State")
+
+}
+
+extension Notification {
+
+    static func blinkyDidConnect(_ blinkyPeripheral: BlinkyPeripheral) -> Notification {
+        return Notification(name: .connection, object: blinkyPeripheral)
+    }
+
+    static func blinky(_ blinkyPeripheral: BlinkyPeripheral,
+                       didBecameReadyWithLedSupported ledSupported: Bool,
+                       buttonSupported: Bool) -> Notification {
+        return Notification(name: .ready, object: blinkyPeripheral,
+                userInfo: ["ledSupported": ledSupported,
+                           "buttonSupported": buttonSupported])
+    }
+
+    static func blinkyDidDisconnect(_ blinkyPeripheral: BlinkyPeripheral) -> Notification {
+        return Notification(name: .disconnection, object: blinkyPeripheral)
+    }
+
+    static func ledState(of blinkyPeripheral: BlinkyPeripheral, didChangeTo isOn: Bool) -> Notification {
+        return Notification(name: .ledState, object: blinkyPeripheral, userInfo: ["isOn": isOn])
+    }
+
+    static func buttonState(of blinkyPeripheral: BlinkyPeripheral, didChangeTo isPressed: Bool) -> Notification {
+        return Notification(name: .buttonState, object: blinkyPeripheral, userInfo: ["isPressed": isPressed])
+    }
+
+}
+
+extension BlinkyPeripheral {
+
+    func post(_ notification: Notification) {
+        NotificationCenter.default.post(notification)
+    }
+
+    func dispose(_ observer: NSObjectProtocol) {
+        NotificationCenter.default.removeObserver(observer)
+    }
+
+    private func on(_ name: Notification.Name, do action: @escaping (Notification) -> ()) -> NSObjectProtocol {
+        return NotificationCenter.default.addObserver(forName: name, object: self, queue: OperationQueue.main, using: action)
+    }
+
+    func onConnected(do action: @escaping () -> ()) {
+        var observer: NSObjectProtocol?
+        observer = on(.connection) { [unowned self] notification in
+            self.dispose(observer!)
+            action()
+        }
+    }
+
+    func onReady(do action: @escaping (Bool, Bool) -> ()) {
+        var observer: NSObjectProtocol?
+        observer = on(.ready) { [unowned self] notification in
+            self.dispose(observer!)
+            if let userInfo = notification.userInfo,
+               let ledSupported = userInfo["ledSupported"] as? Bool,
+               let buttonSupported = userInfo["buttonSupported"] as? Bool {
+                action(ledSupported, buttonSupported)
+            }
+        }
+    }
+
+    func onDisconnected(do action: @escaping () -> ()) {
+        var observer: NSObjectProtocol?
+        observer = on(.disconnection) { [unowned self] notification in
+            self.dispose(observer!)
+            action()
+        }
+    }
+
+    func onLedStateDidChange(do action: @escaping (Bool) -> ()) -> NSObjectProtocol {
+        return on(.ledState) { notification in
+            if let userInfo = notification.userInfo,
+               let isOn = userInfo["isOn"] as? Bool {
+                action(isOn)
+            }
+        }
+    }
+
+    func onButtonStateDidChange(do action: @escaping (Bool) -> ()) -> NSObjectProtocol {
+        return on(.buttonState) { notification in
+            if let userInfo = notification.userInfo,
+               let isPressed = userInfo["isPressed"] as? Bool {
+                action(isPressed)
+            }
+        }
+    }
+
+}

--- a/Example/nRFBlinky/ViewControllers/ScannerView/BlinkyTableViewCell.swift
+++ b/Example/nRFBlinky/ViewControllers/ScannerView/BlinkyTableViewCell.swift
@@ -45,25 +45,26 @@ class BlinkyTableViewCell: UITableViewCell {
     
     // MARK: - Implementation
 
-    public func setupView(withPeripheral aPeripheral: BlinkyPeripheral) {
-        accessibilityLabel = aPeripheral.advertisedName
-        peripheralName.text = aPeripheral.advertisedName
+    public func setupView(withPeripheral peripheral: BlinkyPeripheral) {
+        accessibilityLabel = peripheral.advertisedName
+        peripheralName.text = peripheral.advertisedName
 
-        if aPeripheral.RSSI.decimalValue < -60 {
+        switch peripheral.RSSI.decimalValue {
+        case let rssi where rssi < -75:
             peripheralRSSIIcon.image = #imageLiteral(resourceName: "rssi_2")
-        } else if aPeripheral.RSSI.decimalValue < -50 {
+        case let rssi where rssi < -55:
             peripheralRSSIIcon.image = #imageLiteral(resourceName: "rssi_3")
-        } else if aPeripheral.RSSI.decimalValue < -30 {
+        case let rssi where rssi < -30:
             peripheralRSSIIcon.image = #imageLiteral(resourceName: "rssi_4")
-        } else {
+        default:
             peripheralRSSIIcon.image = #imageLiteral(resourceName: "rssi_1")
         }
     }
     
-    public func peripheralUpdatedAdvertisementData(_ aPeripheral: BlinkyPeripheral) {
+    public func peripheralUpdatedAdvertisementData(_ peripheral: BlinkyPeripheral) {
         if Date().timeIntervalSince(lastUpdateTimestamp) > 1.0 {
             lastUpdateTimestamp = Date()
-            setupView(withPeripheral: aPeripheral)
+            setupView(withPeripheral: peripheral)
         }
     }
 }

--- a/Example/nRFBlinky/ViewControllers/ScannerView/ScannerTableViewController.swift
+++ b/Example/nRFBlinky/ViewControllers/ScannerView/ScannerTableViewController.swift
@@ -30,7 +30,7 @@
 
 import UIKit
 
-class ScannerTableViewController: UITableViewController, CBCentralManagerDelegate {
+class ScannerTableViewController: UITableViewController {
     
     // MARK: - Outlets and Actions
     
@@ -38,52 +38,53 @@ class ScannerTableViewController: UITableViewController, CBCentralManagerDelegat
     @IBOutlet weak var activityIndicator: UIActivityIndicatorView!
     
     // MARK: - Properties
-    
-    private var centralManager: CBCentralManager!
-    private var discoveredPeripherals = [BlinkyPeripheral]()
+
+    private var manager: BlinkyManager!
     
     // MARK: - UIViewController
-    
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        
-        discoveredPeripherals.removeAll()
-        tableView.reloadData()
-    }
-    
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        
-        centralManager.delegate = self
-        if centralManager.state == .poweredOn,
-           centralManager.isScanning == false {
-            activityIndicator.startAnimating()
-            centralManager.scanForPeripherals(
-                withServices: [BlinkyPeripheral.nordicBlinkyServiceUUID],
-                options: [CBCentralManagerScanOptionAllowDuplicatesKey : true]
-            )
-        }
-    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
         tableView.isAccessibilityElement = true
         tableView.accessibilityLabel = "Scan Results"
         tableView.accessibilityIdentifier = "scanResults"
-        
-        centralManager = CBCentralManagerFactory.instance(
-            delegate: self,
-            queue: nil,
-            options: [CBCentralManagerOptionShowPowerAlertKey : true],
-            forceMock: (UIApplication.shared.delegate as! AppDelegate).mockingEnabled
-        )
+
+        let mock = (UIApplication.shared.delegate as! AppDelegate).mockingEnabled
+        manager = BlinkyManager(mock)
+        _ = manager.onStateChange { [unowned self] state in
+            if state == .poweredOn {
+                self.startScan()
+            } else {
+                print("Central is not powered on")
+                self.activityIndicator.stopAnimating()
+            }
+        }
+        _ = manager.onBlinkyDiscovery { [unowned self] blinky in
+            self.addOrUpdateBlinky(blinky)
+        }
+        _ = onPeripheralSelected { [unowned self] blinky in
+            self.stopScan()
+            self.connectBlinky(blinky)
+        }
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        manager.reset()
+        tableView.reloadData()
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        startScan()
     }
 
     override func viewWillTransition(to size: CGSize,
                                      with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
+        // This will rotate the view displayed when there are no peripherals scanned.
         if view.subviews.contains(emptyPeripheralsView) {
-            coordinator.animate(alongsideTransition: { (context) in
+            coordinator.animate(alongsideTransition: { context in
                 let width = self.emptyPeripheralsView.frame.width
                 let height = self.emptyPeripheralsView.frame.height
                 if context.containerView.frame.height > context.containerView.frame.width {
@@ -104,12 +105,12 @@ class ScannerTableViewController: UITableViewController, CBCentralManagerDelegat
     // MARK: - UITableViewDelegate
     
     override func numberOfSections(in tableView: UITableView) -> Int {
-        if discoveredPeripherals.count > 0 {
-            hideEmptyPeripheralsView()
-        } else {
+        if manager.isEmpty {
             showEmptyPeripheralsView()
+        } else {
+            hideEmptyPeripheralsView()
         }
-        return discoveredPeripherals.count > 0 ? 1 : 0
+        return manager.discoveredPeripherals.count > 0 ? 1 : 0
     }
     
     override func tableView(_ tableView: UITableView,
@@ -119,101 +120,24 @@ class ScannerTableViewController: UITableViewController, CBCentralManagerDelegat
 
     override func tableView(_ tableView: UITableView,
                             numberOfRowsInSection section: Int) -> Int {
-        return discoveredPeripherals.count
+        return manager.discoveredPeripherals.count
     }
     
     override func tableView(_ tableView: UITableView,
                             cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let aCell = tableView.dequeueReusableCell(
+        let cell = tableView.dequeueReusableCell(
                         withIdentifier: BlinkyTableViewCell.reuseIdentifier,
                         for: indexPath
                     ) as! BlinkyTableViewCell
-        let peripheral = discoveredPeripherals[indexPath.row]
-        aCell.setupView(withPeripheral: peripheral)
-        return aCell
+        let blinky = manager.discoveredPeripherals[indexPath.row]
+        cell.setupView(withPeripheral: blinky)
+        return cell
     }
     
     override func tableView(_ tableView: UITableView,
                             didSelectRowAt indexPath: IndexPath) {
-        centralManager.stopScan()
-        activityIndicator.stopAnimating()
         tableView.deselectRow(at: indexPath, animated: true)
-        performSegue(withIdentifier: "PushBlinkyView",
-                     sender: discoveredPeripherals[indexPath.row])
-    }
-    
-    // MARK: - CBCentralManagerDelegate
-    
-    func centralManager(_ central: CBCentralManager,
-                        willRestoreState dict: [String : Any]) {
-        print("Restoring state")
-    }
-    
-    func centralManager(_ central: CBCentralManager,
-                        didDiscover peripheral: CBPeripheral,
-                        advertisementData: [String : Any],
-                        rssi RSSI: NSNumber) {
-        let newPeripheral = BlinkyPeripheral(withPeripheral: peripheral,
-                                             advertisementData: advertisementData,
-                                             andRSSI: RSSI, using: centralManager)
-        if !discoveredPeripherals.contains(newPeripheral) {
-            discoveredPeripherals.append(newPeripheral)
-            tableView.beginUpdates()
-            if discoveredPeripherals.count == 1 {
-                tableView.insertSections(IndexSet(integer: 0), with: .fade)
-            }
-            tableView.insertRows(
-                at: [IndexPath(row: discoveredPeripherals.count - 1, section: 0)],
-                with: .fade
-            )
-            tableView.endUpdates()
-        } else {
-            if let index = discoveredPeripherals.firstIndex(of: newPeripheral) {
-                if let aCell = tableView.cellForRow(at: [0, index]) as? BlinkyTableViewCell {
-                    aCell.peripheralUpdatedAdvertisementData(newPeripheral)
-                }
-            }
-        }
-    }
-
-    func centralManagerDidUpdateState(_ central: CBCentralManager) {
-        if central.state != .poweredOn {
-            print("Central is not powered on")
-            activityIndicator.stopAnimating()
-        } else {
-            activityIndicator.startAnimating()
-            centralManager.scanForPeripherals(
-                withServices: [BlinkyPeripheral.nordicBlinkyServiceUUID],
-                options: [CBCentralManagerScanOptionAllowDuplicatesKey : true]
-            )
-        }
-    }
-    
-    // MARK: - Implementation
-
-    private func showEmptyPeripheralsView() {
-        if !view.subviews.contains(emptyPeripheralsView) {
-            view.addSubview(emptyPeripheralsView)
-            emptyPeripheralsView.alpha = 0
-            emptyPeripheralsView.frame = CGRect(x: 0,
-                                                y: (view.frame.height / 2) - 180,
-                                                width: view.frame.width,
-                                                height: emptyPeripheralsView.frame.height)
-            view.bringSubviewToFront(emptyPeripheralsView)
-            UIView.animate(withDuration: 0.5, animations: {
-                self.emptyPeripheralsView.alpha = 1
-            })
-        }
-    }
-    
-    private func hideEmptyPeripheralsView() {
-        if view.subviews.contains(emptyPeripheralsView) {
-            UIView.animate(withDuration: 0.5, animations: {
-                self.emptyPeripheralsView.alpha = 0
-            }, completion: { completed in
-                self.emptyPeripheralsView.removeFromSuperview()
-            })
-        }
+        post(.selectPeripheral(at: indexPath.row))
     }
 
     // MARK: - Segue and navigation
@@ -224,10 +148,99 @@ class ScannerTableViewController: UITableViewController, CBCentralManagerDelegat
     
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if segue.identifier == "PushBlinkyView" {
-            if let peripheral = sender as? BlinkyPeripheral {
-                let destinationView = segue.destination as! BlinkyViewController
-                destinationView.setPeripheral(peripheral)
+            if let blinky = sender as? BlinkyPeripheral,
+               let destination = segue.destination as? BlinkyViewController {
+                destination.blinky = blinky
             }
         }
     }
+}
+
+// MARK: - Implementation
+
+private extension ScannerTableViewController {
+
+    func showEmptyPeripheralsView() {
+        if !view.subviews.contains(emptyPeripheralsView) {
+            view.addSubview(emptyPeripheralsView)
+            emptyPeripheralsView.alpha = 0
+            emptyPeripheralsView.frame = CGRect(
+                    x: 0,                    y: (view.frame.height / 2) - 180,
+                    width: view.frame.width, height: emptyPeripheralsView.frame.height)
+            view.bringSubviewToFront(emptyPeripheralsView)
+            UIView.animate(withDuration: 0.5) {
+                self.emptyPeripheralsView.alpha = 1
+            }
+        }
+    }
+
+    func hideEmptyPeripheralsView() {
+        if view.subviews.contains(emptyPeripheralsView) {
+            UIView.animate(withDuration: 0.5, animations: {
+                self.emptyPeripheralsView.alpha = 0
+            }, completion: { completed in
+                self.emptyPeripheralsView.removeFromSuperview()
+            })
+        }
+    }
+
+    func addOrUpdateBlinky(_ blinky: BlinkyPeripheral) {
+        tableView.reloadData()
+    }
+
+    func startScan() {
+        if manager.startScan() {
+            activityIndicator.startAnimating()
+        }
+    }
+
+    func stopScan() {
+        manager.stopScan()
+        activityIndicator.stopAnimating()
+    }
+
+    func connectBlinky(_ blinky: BlinkyPeripheral) {
+        performSegue(withIdentifier: "PushBlinkyView", sender: blinky)
+    }
+
+}
+
+extension Notification.Name {
+
+    static let selection = Notification.Name("Selection")
+
+}
+
+extension Notification {
+
+    static func selectPeripheral(at index: Int) -> Notification {
+        return Notification(name: .selection, userInfo: ["row": index])
+    }
+
+}
+
+private extension ScannerTableViewController {
+
+    func post(_ notification: Notification) {
+        NotificationCenter.default.post(notification)
+    }
+
+    func dispose(_ observer: NSObjectProtocol) {
+        NotificationCenter.default.removeObserver(observer)
+    }
+
+    private func on(_ name: Notification.Name, do action: @escaping (Notification) -> ()) -> NSObjectProtocol {
+        return NotificationCenter.default.addObserver(forName: name, object: nil, queue: nil, using: action)
+    }
+
+    func onPeripheralSelected(do action: @escaping (BlinkyPeripheral) -> ()) -> NSObjectProtocol {
+        return on(.selection) { notification in
+            if let userInfo = notification.userInfo,
+               let index = userInfo["row"] as? Int {
+                let blinky = self.manager.discoveredPeripherals[index]
+                action(blinky)
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
New features:
* Option to reset peripheral
* Sample app rewritten to use Notifications. This allows UI tests in Unit Tests.

Bugs fixed:
* Fixed an issue, where some BLE operations were still possible after the device was out of range/reset (until the central manager got the callback).

Other improvements:
* Unit tests improved