### PR TITLE
Tearing down improved and Unit Tests fixed

### DIFF
--- a/CoreBluetoothMock/Classes/CBMCentralManagerFactory.swift
+++ b/CoreBluetoothMock/Classes/CBMCentralManagerFactory.swift
@@ -30,7 +30,7 @@
 
 import CoreBluetooth
 
-/// The factory that instantiates the CBMCentralManager object.
+/// The factory that instantiates the `CBMCentralManager` object.
 /// The factory may be used to automatically instantiate either a native
 /// or mock implementation based on the environment. You may also
 /// instantiate the `CBMCentralManagerMock` or `CBMCentralManagerNative` without
@@ -72,7 +72,7 @@ public class CBMCentralManagerFactory {
         #endif
     }
     
-    /// Returns the implementation of CBCentralManager, depending on the environment.
+    /// Returns the implementation of `CBCentralManager`, depending on the environment.
     /// On a simulator, or when the `forceMock` flag is enabled, the mock
     /// implementation is returned, otherwise the native one.
     /// - Parameters:
@@ -80,7 +80,7 @@ public class CBMCentralManagerFactory {
     ///   - queue: The dispatch queue on which the events will be dispatched.
     ///            If <i>nil</i>, the main queue will be used.
     ///   - forceMock: A flag to force mocking also on a physical device.
-    /// - Returns: The implementation of CBCentralManager.
+    /// - Returns: The implementation of `CBCentralManager`.
     public static func instance(delegate: CBMCentralManagerDelegate?,
                                 queue: DispatchQueue?,
                                 forceMock: Bool = false) -> CBMCentralManager {
@@ -93,7 +93,7 @@ public class CBMCentralManagerFactory {
         #endif
     }
     
-    /// Returns the implementation of CBCentralManager, depending on the environment.
+    /// Returns the implementation of `CBCentralManager`, depending on the environment.
     /// On a simulator, or when the `forceMock` flag is enabled, the mock
     /// implementation is returned, otherwise the native one.
     /// - Parameters:
@@ -102,7 +102,7 @@ public class CBMCentralManagerFactory {
     ///            If <i>nil</i>, the main queue will be used.
     ///   - options: An optional dictionary specifying options for the manager.
     ///   - forceMock: A flag to force mocking also on a physical device.
-    /// - Returns: The implementation of CBCentralManager.
+    /// - Returns: The implementation of `CBCentralManager`.
     public static func instance(delegate: CBMCentralManagerDelegate?,
                                 queue: DispatchQueue?,
                                 options: [String : Any]?,

--- a/CoreBluetoothMock/Classes/CBMCentralManagerFactory.swift
+++ b/CoreBluetoothMock/Classes/CBMCentralManagerFactory.swift
@@ -115,12 +115,4 @@ public class CBMCentralManagerFactory {
                 CBMCentralManagerNative(delegate: delegate, queue: queue, options: options)
         #endif
     }
-    
-    /// Remove all active CBMCentralManagerMock instances and mock peripherals
-    /// from the simulation, resetting it to the initial state.
-    /// Use this to tear down your mocks between tests, e.g. in tearDownWithError()
-    /// All manager delegates will receive a powerOff state update.
-    public static func tearDownSimulation() {
-        CBMCentralManagerMock.tearDownSimulation()
-    }
 }

--- a/CoreBluetoothMock/Classes/CBMCentralManagerFactory.swift
+++ b/CoreBluetoothMock/Classes/CBMCentralManagerFactory.swift
@@ -56,12 +56,12 @@ public class CBMCentralManagerFactory {
     public static var simulateFeaturesSupport: ((_ features: CBMCentralManager.Feature) -> Bool)?
     #endif
     
-    /// Returns the implementation of CBCentralManager, depending on the environment.
+    /// Returns the implementation of `CBCentralManager`, depending on the environment.
     /// On a simulator, or when the `forceMock` flag is enabled, the mock
     /// implementation is returned, otherwise the native one.
     /// - Parameters:
     ///   - forceMock: A flag to force mocking also on physical device.
-    /// - Returns: The implementation of CBCentralManager.
+    /// - Returns: The implementation of `CBCentralManager`.
     public static func instance(forceMock: Bool = false) -> CBMCentralManager {
         #if targetEnvironment(simulator)
             return CBMCentralManagerMock()

--- a/Example/Tests/NormalBehaviorTest.swift
+++ b/Example/Tests/NormalBehaviorTest.swift
@@ -76,8 +76,12 @@ class NormalBehaviorTest: XCTestCase {
             found.fulfill()
         }
         wait(for: [found], timeout: 3)
-        XCTAssertNotNil(target)
-
+        XCTAssertNotNil(target, "nRF Blinky not found. Make sure you run the test on a simulator.")
+        if target == nil {
+            // Going further would cause a crash.
+            return
+        }
+        
         // Select found device.
         Sim.post(.selectPeripheral(at: 0))
 

--- a/Example/Tests/NormalBehaviorTest.swift
+++ b/Example/Tests/NormalBehaviorTest.swift
@@ -32,16 +32,27 @@ import XCTest
 @testable import nRF_Blinky
 @testable import CoreBluetoothMock
 
+/// This test simulates normal behavior of a device with Nordic LED Button service.
+/// 
+/// It is using the app and testing it by sending notifications that trigger different
+/// actions.
 class NormalBehaviorTest: XCTestCase {
 
     override func setUp() {
-        (UIApplication.shared.delegate as! AppDelegate).mockingEnabled = true
+        // This method is called AFTER ScannerTableViewController.viewDidLoad()
+        // where the BlinkyManager is instantiated. A separate mock manager
+        // is not created in this test.
+        // Initially mock Bluetooth adapter is powered Off.
         CBMCentralManagerMock.simulatePeripherals([blinky, hrm, thingy])
         CBMCentralManagerMock.simulateInitialState(.poweredOn)
     }
 
     override func tearDown() {
-        CBMCentralManagerMock.tearDownSimulation()
+        // We can't call CBMCentralManagerMock.tearDownSimulation() here.
+        // That would invalidate the BlinkyManager in ScannerTableViewController.
+        // The central manager must be reused, so let's just power mock off,
+        // which will allow us to set different set of peripherals in another test.
+        CBMCentralManagerMock.simulatePowerOff()
     }
 
     func testScanningBlinky() {

--- a/Example/Tests/ResetTest.swift
+++ b/Example/Tests/ResetTest.swift
@@ -32,16 +32,27 @@ import XCTest
 @testable import nRF_Blinky
 @testable import CoreBluetoothMock
 
+/// This test simulates a device with Nordic LED Button service which gets reset during
+/// connection.
+///
+/// It is using the app and testing it by sending notifications that trigger different
+/// actions.
 class ResetTest: XCTestCase {
 
     override func setUp() {
-        (UIApplication.shared.delegate as! AppDelegate).mockingEnabled = true
+        // This method is called AFTER ScannerTableViewController.viewDidLoad()
+        // where the BlinkyManager is instantiated.
+        // Initially mock Bluetooth adapter is powered Off.
         CBMCentralManagerMock.simulatePeripherals([blinky, hrm, thingy])
         CBMCentralManagerMock.simulatePowerOn()
     }
 
     override func tearDown() {
-        CBMCentralManagerMock.tearDownSimulation()
+        // We can't call CBMCentralManagerMock.tearDownSimulation() here.
+        // That would invalidate the BlinkyManager in ScannerTableViewController.
+        // The central manager must be reused, so let's just power mock off,
+        // which will allow us to set different set of peripherals in another test.
+        CBMCentralManagerMock.simulatePowerOff()
     }
 
     func testScanningBlinky() {

--- a/Example/Tests/ResetTest.swift
+++ b/Example/Tests/ResetTest.swift
@@ -76,7 +76,11 @@ class ResetTest: XCTestCase {
             found.fulfill()
         }
         wait(for: [found], timeout: 3)
-        XCTAssertNotNil(target)
+        XCTAssertNotNil(target, "nRF Blinky not found. Make sure you run the test on a simulator.")
+        if target == nil {
+            // Going further would cause a crash.
+            return
+        }
 
         // Select found device.
         Sim.post(.selectPeripheral(at: 0))

--- a/README.md
+++ b/README.md
@@ -27,12 +27,14 @@ forwarded to their native equivalents, but on a simulator a mock implementation 
 
 ## How to start
 
-The *Core Bluetooth Mock* library is available only in Swift, and compatible with iOS 8.0+. For projects running Objective-C 
-we recommend https://github.com/Rightpoint/RZBluetooth library.
+The *Core Bluetooth Mock* library is available only in Swift, and compatible with iOS 8.0+, macOS 10.13+, tvOS 9.0+ and watchOS 2.0+,
+with some features available only on newer platforms.
+For projects running Objective-C we recommend https://github.com/Rightpoint/RZBluetooth library.
 
 ### Including the library
 
-The library support CocoaPods, Carthage and Swift Package Manager.
+The library support [CocoaPods](https://github.com/CocoaPods/CocoaPods), [Carthage](https://github.com/Carthage/Carthage) and 
+[Swift Package Manager](https://swift.org/package-manager).
 
 #### CocoaPods
 
@@ -141,7 +143,10 @@ any central manager instance was created. It defines the intial state of the moc
 `CBMCentralManager.simulatePowerOff()` - turns off the mock central manager. All scans and connections will be terminated.
 
 `CBMCentralManagerMock.simulatePeripherals(_ peripherals: [CBMPeripheralSpec])` - defines list of 
-mock peripheral. This method should be called once, before any central manager was initialized.
+mock peripheral. This method should be called when the manager is powered off, or before any central manager was initialized.
+
+`CBMCentralManagerMock.tearDownSimulation()` - sets the state of all currently existing central managers to `.unknown` and
+clears the list of managers and peripherals bringing the mock manager to initial state.
 
 See [AppDelegate.swift](Example/nRFBlinky/AppDelegate.swift#L48) for reference. In the sample app the mock implementation is
 used only in UI Tests, which lauch the app with `mocking-enabled` parameter (see [here](Example/UI%20Tests/UITests.swift#L42)),
@@ -179,7 +184,7 @@ with `CBMCentralManagerOptionRestoreIdentifierKey` option. The map returned will
 `centralManager(:willRestoreState:)` callback in central manager's delegate.
 
 `CBMCentralManagerFactory.simulateFeaturesSupport` - this closure will be used to emulate Bluetooth features supported
-by the manager. It is availalbe on iOS 13+.
+by the manager. It is availalbe on iOS 13+, tvOS 13+ or watchOS 6+.
 
 ## Sample application: nRF BLINKY
 


### PR DESCRIPTION
This PR improves `tearDownSimulation()` method added in #18.
It is not required to tear down the test before starting a new one. The manager may be powered off using `CBMCentralManagerMock.simulatePowerOff()`, which allows to set new test peripheral specifications.
Tearing down will invalidate all current instances of `CBMCentralManagerMock`, so new instances will have to be created.