### PR TITLE
Version 0.11.0

### DIFF
--- a/CoreBluetoothMock.podspec
+++ b/CoreBluetoothMock.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'CoreBluetoothMock'
-  s.version          = '0.10.0'
+  s.version          = '0.11.0'
   s.summary          = 'Mocking library for CoreBluetooth.'
 
   s.description      = <<-DESC

--- a/CoreBluetoothMock/Classes/CBMCentralManagerFactory.swift
+++ b/CoreBluetoothMock/Classes/CBMCentralManagerFactory.swift
@@ -30,7 +30,7 @@
 
 import CoreBluetooth
 
-/// The factory that instantiates the CBMCentralManager object.
+/// The factory that instantiates the `CBMCentralManager` object.
 /// The factory may be used to automatically instantiate either a native
 /// or mock implementation based on the environment. You may also
 /// instantiate the `CBMCentralManagerMock` or `CBMCentralManagerNative` without
@@ -56,12 +56,12 @@ public class CBMCentralManagerFactory {
     public static var simulateFeaturesSupport: ((_ features: CBMCentralManager.Feature) -> Bool)?
     #endif
     
-    /// Returns the implementation of CBCentralManager, depending on the environment.
+    /// Returns the implementation of `CBCentralManager`, depending on the environment.
     /// On a simulator, or when the `forceMock` flag is enabled, the mock
     /// implementation is returned, otherwise the native one.
     /// - Parameters:
     ///   - forceMock: A flag to force mocking also on physical device.
-    /// - Returns: The implementation of CBCentralManager.
+    /// - Returns: The implementation of `CBCentralManager`.
     public static func instance(forceMock: Bool = false) -> CBMCentralManager {
         #if targetEnvironment(simulator)
             return CBMCentralManagerMock()
@@ -72,7 +72,7 @@ public class CBMCentralManagerFactory {
         #endif
     }
     
-    /// Returns the implementation of CBCentralManager, depending on the environment.
+    /// Returns the implementation of `CBCentralManager`, depending on the environment.
     /// On a simulator, or when the `forceMock` flag is enabled, the mock
     /// implementation is returned, otherwise the native one.
     /// - Parameters:
@@ -80,7 +80,7 @@ public class CBMCentralManagerFactory {
     ///   - queue: The dispatch queue on which the events will be dispatched.
     ///            If <i>nil</i>, the main queue will be used.
     ///   - forceMock: A flag to force mocking also on a physical device.
-    /// - Returns: The implementation of CBCentralManager.
+    /// - Returns: The implementation of `CBCentralManager`.
     public static func instance(delegate: CBMCentralManagerDelegate?,
                                 queue: DispatchQueue?,
                                 forceMock: Bool = false) -> CBMCentralManager {
@@ -93,7 +93,7 @@ public class CBMCentralManagerFactory {
         #endif
     }
     
-    /// Returns the implementation of CBCentralManager, depending on the environment.
+    /// Returns the implementation of `CBCentralManager`, depending on the environment.
     /// On a simulator, or when the `forceMock` flag is enabled, the mock
     /// implementation is returned, otherwise the native one.
     /// - Parameters:
@@ -102,7 +102,7 @@ public class CBMCentralManagerFactory {
     ///            If <i>nil</i>, the main queue will be used.
     ///   - options: An optional dictionary specifying options for the manager.
     ///   - forceMock: A flag to force mocking also on a physical device.
-    /// - Returns: The implementation of CBCentralManager.
+    /// - Returns: The implementation of `CBCentralManager`.
     public static func instance(delegate: CBMCentralManagerDelegate?,
                                 queue: DispatchQueue?,
                                 options: [String : Any]?,
@@ -114,13 +114,5 @@ public class CBMCentralManagerFactory {
                 CBMCentralManagerMock(delegate: delegate, queue: queue, options: options) :
                 CBMCentralManagerNative(delegate: delegate, queue: queue, options: options)
         #endif
-    }
-    
-    /// Remove all active CBMCentralManagerMock instances and mock peripherals
-    /// from the simulation, resetting it to the initial state.
-    /// Use this to tear down your mocks between tests, e.g. in tearDownWithError()
-    /// All manager delegates will receive a powerOff state update.
-    public static func tearDownSimulation() {
-        CBMCentralManagerMock.tearDownSimulation()
     }
 }

--- a/CoreBluetoothMock/Classes/CBMCentralManagerFactory.swift
+++ b/CoreBluetoothMock/Classes/CBMCentralManagerFactory.swift
@@ -116,4 +116,11 @@ public class CBMCentralManagerFactory {
         #endif
     }
     
+    /// Remove all active CBMCentralManagerMock instances and mock peripherals
+    /// from the simulation, resetting it to the initial state.
+    /// Use this to tear down your mocks between tests, e.g. in tearDownWithError()
+    /// All manager delegates will receive a powerOff state update.
+    public static func tearDownSimulation() {
+        CBMCentralManagerMock.tearDownSimulation()
+    }
 }

--- a/CoreBluetoothMock/Classes/CBMCentralManagerMock.swift
+++ b/CoreBluetoothMock/Classes/CBMCentralManagerMock.swift
@@ -143,6 +143,16 @@ public class CBMCentralManagerMock: NSObject, CBMCentralManager {
         }
     }
     
+    /// Remove all active CBMCentralManagerMock instances and mock peripherals
+    /// from the simulation, resetting it to the initial state.
+    /// Use this to tear down your mocks between tests, e.g. in tearDownWithError()
+    /// All manager delegates will receive a powerOff state update.
+    public static func tearDownSimulation() {
+        managerState = .poweredOff
+        managers.removeAll()
+        peripherals.removeAll()
+    }
+    
     // MARK: - Central manager simulation methods
     
     /// Sets the initial state of the Bluetooth central manager.
@@ -164,7 +174,9 @@ public class CBMCentralManagerMock: NSObject, CBMCentralManager {
     /// - Parameter peripherals: Peripherals that are not connected.
     public static func simulatePeripherals(_ peripherals: [CBMPeripheralSpec]) {
         guard managers.isEmpty, CBMCentralManagerMock.peripherals.isEmpty else {
-            NSLog("Warning: Peripherals can be added to simulation only once, and not after any central manager was initiated")
+            NSLog("Warning: Peripherals can not be added while the simulation is running. " +
+                  "Add peripherals before getting a CBMCentralManagerMock instance, " +
+                  "or after calling CBMCentralManagerFactory.tearDownInstances()")
             return
         }
         CBMCentralManagerMock.peripherals = peripherals

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - CoreBluetoothMock (0.10.0)
+  - CoreBluetoothMock (0.11.0)
 
 DEPENDENCIES:
   - CoreBluetoothMock (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  CoreBluetoothMock: 4db6f2f85f268596cb05595d0ccc338212578e93
+  CoreBluetoothMock: 158792f5f41671d5c61b882c38e804f35e0b9339
 
 PODFILE CHECKSUM: bfd9fc7193b211c18bbe632884c30bc5d6a4807c
 

--- a/Example/Pods/Local Podspecs/CoreBluetoothMock.podspec.json
+++ b/Example/Pods/Local Podspecs/CoreBluetoothMock.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "CoreBluetoothMock",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "summary": "Mocking library for CoreBluetooth.",
   "description": "This is a mocking library for CoreBluetooth framework. Allows to mock a Bluetooth Low Energy\ndevice and test the app on simulator.",
   "homepage": "https://github.com/NordicSemiconductor/IOS-CoreBluetooth-Mock",
@@ -13,7 +13,7 @@
   },
   "source": {
     "git": "https://github.com/NordicSemiconductor/IOS-CoreBluetooth-Mock.git",
-    "tag": "0.10.0"
+    "tag": "0.11.0"
   },
   "social_media_url": "https://twitter.com/nordictweets",
   "platforms": {

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -1,5 +1,5 @@
 PODS:
-  - CoreBluetoothMock (0.10.0)
+  - CoreBluetoothMock (0.11.0)
 
 DEPENDENCIES:
   - CoreBluetoothMock (from `../`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  CoreBluetoothMock: 4db6f2f85f268596cb05595d0ccc338212578e93
+  CoreBluetoothMock: 158792f5f41671d5c61b882c38e804f35e0b9339
 
 PODFILE CHECKSUM: bfd9fc7193b211c18bbe632884c30bc5d6a4807c
 

--- a/Example/Pods/Target Support Files/CoreBluetoothMock/CoreBluetoothMock-Info.plist
+++ b/Example/Pods/Target Support Files/CoreBluetoothMock/CoreBluetoothMock-Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.10.0</string>
+  <string>0.11.0</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/Example/Tests/NormalBehaviorTest.swift
+++ b/Example/Tests/NormalBehaviorTest.swift
@@ -41,7 +41,7 @@ class NormalBehaviorTest: XCTestCase {
     }
 
     override func tearDown() {
-        CBMCentralManagerMock.simulatePowerOff()
+        CBMCentralManagerMock.tearDownSimulation()
     }
 
     func testScanningBlinky() {

--- a/Example/Tests/NormalBehaviorTest.swift
+++ b/Example/Tests/NormalBehaviorTest.swift
@@ -32,16 +32,27 @@ import XCTest
 @testable import nRF_Blinky
 @testable import CoreBluetoothMock
 
+/// This test simulates normal behavior of a device with Nordic LED Button service.
+/// 
+/// It is using the app and testing it by sending notifications that trigger different
+/// actions.
 class NormalBehaviorTest: XCTestCase {
 
     override func setUp() {
-        (UIApplication.shared.delegate as! AppDelegate).mockingEnabled = true
+        // This method is called AFTER ScannerTableViewController.viewDidLoad()
+        // where the BlinkyManager is instantiated. A separate mock manager
+        // is not created in this test.
+        // Initially mock Bluetooth adapter is powered Off.
         CBMCentralManagerMock.simulatePeripherals([blinky, hrm, thingy])
         CBMCentralManagerMock.simulateInitialState(.poweredOn)
     }
 
     override func tearDown() {
-        CBMCentralManagerMock.tearDownSimulation()
+        // We can't call CBMCentralManagerMock.tearDownSimulation() here.
+        // That would invalidate the BlinkyManager in ScannerTableViewController.
+        // The central manager must be reused, so let's just power mock off,
+        // which will allow us to set different set of peripherals in another test.
+        CBMCentralManagerMock.simulatePowerOff()
     }
 
     func testScanningBlinky() {
@@ -65,8 +76,12 @@ class NormalBehaviorTest: XCTestCase {
             found.fulfill()
         }
         wait(for: [found], timeout: 3)
-        XCTAssertNotNil(target)
-
+        XCTAssertNotNil(target, "nRF Blinky not found. Make sure you run the test on a simulator.")
+        if target == nil {
+            // Going further would cause a crash.
+            return
+        }
+        
         // Select found device.
         Sim.post(.selectPeripheral(at: 0))
 

--- a/Example/Tests/ResetTest.swift
+++ b/Example/Tests/ResetTest.swift
@@ -41,7 +41,7 @@ class ResetTest: XCTestCase {
     }
 
     override func tearDown() {
-        CBMCentralManagerMock.simulatePowerOff()
+        CBMCentralManagerMock.tearDownSimulation()
     }
 
     func testScanningBlinky() {

--- a/README.md
+++ b/README.md
@@ -27,12 +27,14 @@ forwarded to their native equivalents, but on a simulator a mock implementation 
 
 ## How to start
 
-The *Core Bluetooth Mock* library is available only in Swift, and compatible with iOS 8.0+. For projects running Objective-C 
-we recommend https://github.com/Rightpoint/RZBluetooth library.
+The *Core Bluetooth Mock* library is available only in Swift, and compatible with iOS 8.0+, macOS 10.13+, tvOS 9.0+ and watchOS 2.0+,
+with some features available only on newer platforms.
+For projects running Objective-C we recommend https://github.com/Rightpoint/RZBluetooth library.
 
 ### Including the library
 
-The library support CocoaPods, Carthage and Swift Package Manager.
+The library support [CocoaPods](https://github.com/CocoaPods/CocoaPods), [Carthage](https://github.com/Carthage/Carthage) and 
+[Swift Package Manager](https://swift.org/package-manager).
 
 #### CocoaPods
 
@@ -141,7 +143,10 @@ any central manager instance was created. It defines the intial state of the moc
 `CBMCentralManager.simulatePowerOff()` - turns off the mock central manager. All scans and connections will be terminated.
 
 `CBMCentralManagerMock.simulatePeripherals(_ peripherals: [CBMPeripheralSpec])` - defines list of 
-mock peripheral. This method should be called once, before any central manager was initialized.
+mock peripheral. This method should be called when the manager is powered off, or before any central manager was initialized.
+
+`CBMCentralManagerMock.tearDownSimulation()` - sets the state of all currently existing central managers to `.unknown` and
+clears the list of managers and peripherals bringing the mock manager to initial state.
 
 See [AppDelegate.swift](Example/nRFBlinky/AppDelegate.swift#L48) for reference. In the sample app the mock implementation is
 used only in UI Tests, which lauch the app with `mocking-enabled` parameter (see [here](Example/UI%20Tests/UITests.swift#L42)),
@@ -179,7 +184,7 @@ with `CBMCentralManagerOptionRestoreIdentifierKey` option. The map returned will
 `centralManager(:willRestoreState:)` callback in central manager's delegate.
 
 `CBMCentralManagerFactory.simulateFeaturesSupport` - this closure will be used to emulate Bluetooth features supported
-by the manager. It is availalbe on iOS 13+.
+by the manager. It is availalbe on iOS 13+, tvOS 13+ or watchOS 6+.
 
 ## Sample application: nRF BLINKY
 


### PR DESCRIPTION
Improvements in this version:
- new `CBMCentralManagerMock.tearDownSimulation()` method that will reset the mock manager to initial state (#18, #20)
- Setting peripherals for simulation is now possible even with some mock central managers instantiated, but only when manager is powered off (#20)
- UI Tests fixed (#19)
- Unit tests fixed (#20)   