### PR TITLE
Reset peripheral state to .disconnected after a failed connect attempt

### DIFF
--- a/CoreBluetoothMock/Classes/CBMCentralManagerMock.swift
+++ b/CoreBluetoothMock/Classes/CBMCentralManagerMock.swift
@@ -681,6 +681,8 @@ public class CBMPeripheralMock: CBMPeer, CBMPeripheral {
                     self.state = .connected
                     self._canSendWriteWithoutResponse = true
                     self.mock.virtualConnections += 1
+                } else {
+                    self.state = .disconnected
                 }
                 completion(result)
             }


### PR DESCRIPTION
This avoids leaving the peripheral object in a broken, un-connectable state.