### PR TITLE
Open public classes up for subclassing

### DIFF
--- a/CoreBluetoothMock/Classes/CBMCentralManagerMock.swift
+++ b/CoreBluetoothMock/Classes/CBMCentralManagerMock.swift
@@ -67,11 +67,11 @@ open class CBMCentralManagerMock: NSObject, CBMCentralManager {
         }
     }
     
-    public weak var delegate: CBMCentralManagerDelegate?
-    public var state: CBMManagerState {
+    open weak var delegate: CBMCentralManagerDelegate?
+    open var state: CBMManagerState {
         return initialized ? CBMCentralManagerMock.managerState : .unknown
     }
-    public private(set) var isScanning: Bool
+    open private(set) var isScanning: Bool
     private var scanFilter: [CBMUUID]?
     private var scanOptions: [String : Any]?
 
@@ -438,7 +438,7 @@ open class CBMCentralManagerMock: NSObject, CBMCentralManager {
         }
     }
     
-    public func scanForPeripherals(withServices serviceUUIDs: [CBMUUID]?,
+    open func scanForPeripherals(withServices serviceUUIDs: [CBMUUID]?,
                                    options: [String : Any]?) {
         // Central manager must be in powered on state.
         guard ensurePoweredOn() else { return }
@@ -479,7 +479,7 @@ open class CBMCentralManagerMock: NSObject, CBMCentralManager {
             }
     }
     
-    public func stopScan() {
+    open func stopScan() {
         // Central manager must be in powered on state.
         guard ensurePoweredOn() else { return }
         isScanning = false
@@ -487,7 +487,7 @@ open class CBMCentralManagerMock: NSObject, CBMCentralManager {
         scanOptions = nil
     }
     
-    public func connect(_ peripheral: CBMPeripheral,
+    open func connect(_ peripheral: CBMPeripheral,
                         options: [String : Any]?) {
         // Central manager must be in powered on state.
         guard ensurePoweredOn() else { return }
@@ -516,7 +516,7 @@ open class CBMCentralManagerMock: NSObject, CBMCentralManager {
         }
     }
     
-    public func cancelPeripheralConnection(_ peripheral: CBMPeripheral) {
+    open func cancelPeripheralConnection(_ peripheral: CBMPeripheral) {
         // Central manager must be in powered on state.
         guard ensurePoweredOn() else { return }
         // Ignore peripherals that are not mocks.
@@ -534,7 +534,7 @@ open class CBMCentralManagerMock: NSObject, CBMCentralManager {
         }
     }
     
-    public func retrievePeripherals(withIdentifiers identifiers: [UUID]) -> [CBMPeripheral] {
+    open func retrievePeripherals(withIdentifiers identifiers: [UUID]) -> [CBMPeripheral] {
         // Starting from iOS 13, this method returns peripherals only in ON state.
         guard ensurePoweredOn() else { return [] }
         // Get the peripherals already known to this central manager.
@@ -564,7 +564,7 @@ open class CBMCentralManagerMock: NSObject, CBMCentralManager {
             }
     }
     
-    public func retrieveConnectedPeripherals(withServices serviceUUIDs: [CBMUUID]) -> [CBMPeripheral] {
+    open func retrieveConnectedPeripherals(withServices serviceUUIDs: [CBMUUID]) -> [CBMPeripheral] {
         // Starting from iOS 13, this method returns peripherals only in ON state.
         guard ensurePoweredOn() else { return [] }
         // Get the connected peripherals with at least one of the given services
@@ -607,7 +607,7 @@ open class CBMCentralManagerMock: NSObject, CBMCentralManager {
     }
     
     @available(iOS 13.0, *)
-    public func registerForConnectionEvents(options: [CBMConnectionEventMatchingOption : Any]?) {
+    open func registerForConnectionEvents(options: [CBMConnectionEventMatchingOption : Any]?) {
         fatalError("Mock connection events are not implemented")
     }
     
@@ -652,12 +652,12 @@ open class CBMPeripheralMock: CBMPeer, CBMPeripheral {
     /// and iOS had chance to read device name.
     fileprivate var wasConnected: Bool = false
     
-    public var delegate: CBMPeripheralDelegate?
+    open var delegate: CBMPeripheralDelegate?
     
-    public override var identifier: UUID {
+    open override var identifier: UUID {
         return mock.identifier
     }
-    public var name: String? {
+    open var name: String? {
         // If the device wasn't connected and has just been scanned first time,
         // return nil. When scanning continued, the Local Name from the
         // advertisement data is returned. When the device was connected, the
@@ -669,12 +669,12 @@ open class CBMPeripheralMock: CBMPeer, CBMPeripheral {
                 nil
     }
     @available(iOS 11.0, tvOS 11.0, watchOS 4.0, *)
-    public var canSendWriteWithoutResponse: Bool {
+    open var canSendWriteWithoutResponse: Bool {
         return _canSendWriteWithoutResponse
     }
-    public private(set) var ancsAuthorized: Bool = false
-    public private(set) var state: CBMPeripheralState = .disconnected
-    public private(set) var services: [CBMService]? = nil
+    open private(set) var ancsAuthorized: Bool = false
+    open private(set) var state: CBMPeripheralState = .disconnected
+    open private(set) var services: [CBMService]? = nil
     
     // MARK: Initializers
     
@@ -852,7 +852,7 @@ open class CBMPeripheralMock: CBMPeer, CBMPeripheral {
     
     // MARK: Service discovery
     
-    public func discoverServices(_ serviceUUIDs: [CBMUUID]?) {
+    open func discoverServices(_ serviceUUIDs: [CBMUUID]?) {
         // Central manager must be in powered on state.
         guard manager.ensurePoweredOn() else { return }
         guard state == .connected,
@@ -893,7 +893,7 @@ open class CBMPeripheralMock: CBMPeer, CBMPeripheral {
         }
     }
     
-    public func discoverIncludedServices(_ includedServiceUUIDs: [CBMUUID]?,
+    open func discoverIncludedServices(_ includedServiceUUIDs: [CBMUUID]?,
                                          for service: CBMService) {
         // Central manager must be in powered on state.
         guard manager.ensurePoweredOn() else { return }
@@ -951,7 +951,7 @@ open class CBMPeripheralMock: CBMPeer, CBMPeripheral {
         
     }
     
-    public func discoverCharacteristics(_ characteristicUUIDs: [CBMUUID]?,
+    open func discoverCharacteristics(_ characteristicUUIDs: [CBMUUID]?,
                                         for service: CBMService) {
         // Central manager must be in powered on state.
         guard manager.ensurePoweredOn() else { return }
@@ -1008,7 +1008,7 @@ open class CBMPeripheralMock: CBMPeer, CBMPeripheral {
         }
     }
     
-    public func discoverDescriptors(for characteristic: CBMCharacteristic) {
+    open func discoverDescriptors(for characteristic: CBMCharacteristic) {
         // Central manager must be in powered on state.
         guard manager.ensurePoweredOn() else { return }
         guard state == .connected,
@@ -1066,7 +1066,7 @@ open class CBMPeripheralMock: CBMPeer, CBMPeripheral {
     
     // MARK: Read requests
     
-    public func readValue(for characteristic: CBMCharacteristic) {
+    open func readValue(for characteristic: CBMCharacteristic) {
         // Central manager must be in powered on state.
         guard manager.ensurePoweredOn() else { return }
         guard state == .connected,
@@ -1100,7 +1100,7 @@ open class CBMPeripheralMock: CBMPeer, CBMPeripheral {
         }
     }
     
-    public func readValue(for descriptor: CBMDescriptor) {
+    open func readValue(for descriptor: CBMDescriptor) {
         // Central manager must be in powered on state.
         guard manager.ensurePoweredOn() else { return }
         guard state == .connected,
@@ -1136,7 +1136,7 @@ open class CBMPeripheralMock: CBMPeer, CBMPeripheral {
     
     // MARK: Write requests
     
-    public func writeValue(_ data: Data,
+    open func writeValue(_ data: Data,
                            for characteristic: CBMCharacteristic,
                            type: CBMCharacteristicWriteType) {
         // Central manager must be in powered on state.
@@ -1215,7 +1215,7 @@ open class CBMPeripheralMock: CBMPeer, CBMPeripheral {
         }
     }
     
-    public func writeValue(_ data: Data, for descriptor: CBMDescriptor) {
+    open func writeValue(_ data: Data, for descriptor: CBMDescriptor) {
         // Central manager must be in powered on state.
         guard manager.ensurePoweredOn() else { return }
         guard state == .connected,
@@ -1251,7 +1251,7 @@ open class CBMPeripheralMock: CBMPeer, CBMPeripheral {
     }
     
     @available(iOS 9.0, *)
-    public func maximumWriteValueLength(for type: CBMCharacteristicWriteType) -> Int {
+    open func maximumWriteValueLength(for type: CBMCharacteristicWriteType) -> Int {
         // Central manager must be in powered on state.
         guard manager.ensurePoweredOn() else { return 0 }
         guard state == .connected, let mtu = mock.mtu else {
@@ -1262,7 +1262,7 @@ open class CBMPeripheralMock: CBMPeer, CBMPeripheral {
     
     // MARK: Enabling notifications and indications
     
-    public func setNotifyValue(_ enabled: Bool,
+    open func setNotifyValue(_ enabled: Bool,
                                for characteristic: CBMCharacteristic) {
         // Central manager must be in powered on state.
         guard manager.ensurePoweredOn() else { return }
@@ -1304,7 +1304,7 @@ open class CBMPeripheralMock: CBMPeer, CBMPeripheral {
     
     // MARK: Other
     
-    public func readRSSI() {
+    open func readRSSI() {
         // Central manager must be in powered on state.
         guard manager.ensurePoweredOn() else { return }
         queue.async { [weak self] in
@@ -1319,11 +1319,11 @@ open class CBMPeripheralMock: CBMPeer, CBMPeripheral {
     }
     
     @available(iOS 11.0, tvOS 11.0, watchOS 4.0, *)
-    public func openL2CAPChannel(_ PSM: CBML2CAPPSM) {
+    open func openL2CAPChannel(_ PSM: CBML2CAPPSM) {
         fatalError("L2CAP mock is not implemented")
     }
     
-    public override var hash: Int {
+    open override var hash: Int {
         return mock.identifier.hashValue
     }
 }

--- a/CoreBluetoothMock/Classes/CBMCentralManagerMock.swift
+++ b/CoreBluetoothMock/Classes/CBMCentralManagerMock.swift
@@ -30,7 +30,7 @@
 
 import CoreBluetooth
 
-public class CBMCentralManagerMock: NSObject, CBMCentralManager {
+open class CBMCentralManagerMock: NSObject, CBMCentralManager {
     /// Mock RSSI deviation.
     ///
     /// Returned RSSI values will be in range
@@ -623,7 +623,7 @@ public class CBMCentralManagerMock: NSObject, CBMCentralManager {
 
 // MARK: - CBPeripheralMock implementation
 
-public class CBMPeripheralMock: CBMPeer, CBMPeripheral {
+open class CBMPeripheralMock: CBMPeer, CBMPeripheral {
     
     /// The parent central manager.
     private let manager: CBMCentralManagerMock

--- a/CoreBluetoothMock/Classes/CBMServiceTypes.swift
+++ b/CoreBluetoothMock/Classes/CBMServiceTypes.swift
@@ -38,23 +38,23 @@ open class CBMService: CBMAttribute {
     internal var _characteristics: [CBMCharacteristic]?
 
     /// A back-pointer to the peripheral this service belongs to.
-    public internal(set) unowned var peripheral: CBMPeripheral
+    open internal(set) unowned var peripheral: CBMPeripheral
     
     /// The type of the service (primary or secondary).
-    public fileprivate(set) var isPrimary: Bool
+    open fileprivate(set) var isPrimary: Bool
     
     /// The Bluetooth UUID of the attribute.
-    public override var uuid: CBMUUID {
+    open override var uuid: CBMUUID {
         return _uuid
     }
     
     /// A list of included services that have so far been discovered in this service.
-    public var includedServices: [CBMService]? {
+    open var includedServices: [CBMService]? {
         return _includedServices
     }
 
     /// A list of characteristics that have so far been discovered in this service.
-    public var characteristics: [CBMCharacteristic]? {
+    open var characteristics: [CBMCharacteristic]? {
         return _characteristics
     }
     
@@ -107,12 +107,12 @@ internal class CBMServiceNative: CBMService {
 
 open class CBMServiceMock: CBMService {
 
-    public override var includedServices: [CBMService]? {
+    open override var includedServices: [CBMService]? {
         set { _includedServices = newValue }
         get { return _includedServices }
     }
 
-    public override var characteristics: [CBMCharacteristic]? {
+    open override var characteristics: [CBMCharacteristic]? {
         set { _characteristics = newValue }
         get { return _characteristics }
     }
@@ -128,11 +128,11 @@ open class CBMServiceMock: CBMService {
         self.characteristics = characteristics
     }
     
-    public func contains(_ characteristic: CBMCharacteristicMock) -> Bool {
+    open func contains(_ characteristic: CBMCharacteristicMock) -> Bool {
         return _characteristics?.contains(characteristic) ?? false
     }
     
-    public override func isEqual(_ object: Any?) -> Bool {
+    open override func isEqual(_ object: Any?) -> Bool {
         if let other = object as? CBMServiceMock {
             return identifier == other.identifier
         }
@@ -147,27 +147,27 @@ open class CBMCharacteristic: CBMAttribute {
     internal var _descriptors: [CBMDescriptor]?
     
     /// The Bluetooth UUID of the attribute.
-    public override var uuid: CBMUUID {
+    open override var uuid: CBMUUID {
         return _uuid
     }
 
     /// A back-pointer to the service this characteristic belongs to.
-    public internal(set) var service: CBMService
+    open internal(set) var service: CBMService
     
     /// The properties of the characteristic.
     public let properties: CBMCharacteristicProperties
 
     /// The value of the characteristic.
-    public internal(set) var value: Data?
+    open internal(set) var value: Data?
 
     /// A list of the descriptors that have so far been discovered
     /// in this characteristic.
-    public var descriptors: [CBMDescriptor]? {
+    open var descriptors: [CBMDescriptor]? {
         return _descriptors
     }
 
     /// Whether the characteristic is currently notifying or not.
-    public internal(set) var isNotifying: Bool
+    open internal(set) var isNotifying: Bool
 
     /// Returns an initialized characteristic.
     /// - Parameters:
@@ -215,7 +215,7 @@ internal class CBMCharacteristicNative: CBMCharacteristic {
 
 open class CBMCharacteristicMock: CBMCharacteristic {
 
-    public override var descriptors: [CBMDescriptor]? {
+    open override var descriptors: [CBMDescriptor]? {
         set {
             _descriptors = newValue
             _descriptors?.forEach { $0.characteristic = self }
@@ -234,11 +234,11 @@ open class CBMCharacteristicMock: CBMCharacteristic {
         self.descriptors = descriptors
     }
     
-    public func contains(_ descriptor: CBMDescriptor) -> Bool {
+    open func contains(_ descriptor: CBMDescriptor) -> Bool {
         return _descriptors?.contains(descriptor) ?? false
     }
     
-    public override func isEqual(_ object: Any?) -> Bool {
+    open override func isEqual(_ object: Any?) -> Bool {
         if let other = object as? CBMCharacteristicMock {
             return identifier == other.identifier
         }
@@ -251,15 +251,15 @@ open class CBMDescriptor: CBMAttribute {
     private let _uuid: CBMUUID
     
     /// The Bluetooth UUID of the attribute.
-    public override var uuid: CBMUUID {
+    open override var uuid: CBMUUID {
         return _uuid
     }
     
     /// A back-pointer to the characteristic this descriptor belongs to.
-    public internal(set) var characteristic: CBMCharacteristic
+    open internal(set) var characteristic: CBMCharacteristic
 
     /// The value of the descriptor.
-    public internal(set) var value: Any?
+    open internal(set) var value: Any?
     
     /// Returns <i>true</i> if the descriptor is a Client Configuration
     /// Characteristic Descriptor (CCCD); otherwise <i>false</i>.
@@ -304,7 +304,7 @@ open class CBMDescriptorMock: CBMDescriptor {
         super.init(type: uuid)
     }
     
-    public override func isEqual(_ object: Any?) -> Bool {
+    open override func isEqual(_ object: Any?) -> Bool {
         if let other = object as? CBMDescriptorMock {
             return identifier == other.identifier
         }

--- a/CoreBluetoothMock/Classes/CBMServiceTypes.swift
+++ b/CoreBluetoothMock/Classes/CBMServiceTypes.swift
@@ -30,7 +30,7 @@
 
 import CoreBluetooth
 
-public class CBMService: CBMAttribute {
+open class CBMService: CBMAttribute {
     internal let identifier: UUID
     private let _uuid: CBMUUID
     
@@ -105,7 +105,7 @@ internal class CBMServiceNative: CBMService {
     
 }
 
-public class CBMServiceMock: CBMService {
+open class CBMServiceMock: CBMService {
 
     public override var includedServices: [CBMService]? {
         set { _includedServices = newValue }
@@ -140,7 +140,7 @@ public class CBMServiceMock: CBMService {
     }
 }
 
-public class CBMCharacteristic: CBMAttribute {
+open class CBMCharacteristic: CBMAttribute {
     internal let identifier: UUID
     private let _uuid: CBMUUID
     
@@ -213,7 +213,7 @@ internal class CBMCharacteristicNative: CBMCharacteristic {
     }
 }
 
-public class CBMCharacteristicMock: CBMCharacteristic {
+open class CBMCharacteristicMock: CBMCharacteristic {
 
     public override var descriptors: [CBMDescriptor]? {
         set {
@@ -246,7 +246,7 @@ public class CBMCharacteristicMock: CBMCharacteristic {
     }
 }
 
-public class CBMDescriptor: CBMAttribute {
+open class CBMDescriptor: CBMAttribute {
     internal let identifier: UUID
     private let _uuid: CBMUUID
     
@@ -298,7 +298,7 @@ internal class CBMDescriptorNative: CBMDescriptor {
     }
 }
 
-public class CBMDescriptorMock: CBMDescriptor {
+open class CBMDescriptorMock: CBMDescriptor {
     
     public override init(type uuid: CBMUUID) {
         super.init(type: uuid)
@@ -312,7 +312,7 @@ public class CBMDescriptorMock: CBMDescriptor {
     }
 }
 
-public class CBMClientCharacteristicConfigurationDescriptorMock: CBMDescriptorMock {
+open class CBMClientCharacteristicConfigurationDescriptorMock: CBMDescriptorMock {
     
     public init() {
         super.init(type: CBMUUID(string: "2902"))


### PR DESCRIPTION
Fixes #26. I've changed the `public` CBM classes and their members to `open`. This should make the library more flexible for users who wish to customise its behaviour.