### PR TITLE
Keeping in line with the iOS 15 SDK changes, we've made multiple properties weak

### DIFF
--- a/CoreBluetoothMock/Classes/CBMCentralManagerMock.swift
+++ b/CoreBluetoothMock/Classes/CBMCentralManagerMock.swift
@@ -1017,9 +1017,10 @@ open class CBMPeripheralMock: CBMPeer, CBMPeripheral {
               let allServices = mock.services else {
             return
         }
-        guard let services = services, services.contains(characteristic.service),
+        guard let services = services, let characteristicService = characteristic.service,
+              services.contains(characteristicService),
               let originalService = allServices.first(where: {
-                  $0.identifier == characteristic.service.identifier
+                $0.identifier == characteristicService.identifier
               }),
               let originalCharacteristic = originalService.characteristics?.first(where: {
                   $0.identifier == characteristic.identifier
@@ -1074,8 +1075,8 @@ open class CBMPeripheralMock: CBMPeer, CBMPeripheral {
               let interval = mock.connectionInterval else {
             return
         }
-        guard let services = services,
-              services.contains(characteristic.service) else {
+        guard let services = services, let characteristicService = characteristic.service,
+              services.contains(characteristicService) else {
             return
         }
         switch delegate.peripheral(mock,
@@ -1108,8 +1109,8 @@ open class CBMPeripheralMock: CBMPeer, CBMPeripheral {
               let interval = mock.connectionInterval else {
             return
         }
-        guard let services = services,
-              services.contains(descriptor.characteristic.service) else {
+        guard let services = services, let descriptorService = descriptor.characteristic?.service,
+              services.contains(descriptorService) else {
             return
         }
         switch delegate.peripheral(mock,
@@ -1147,8 +1148,8 @@ open class CBMPeripheralMock: CBMPeer, CBMPeripheral {
               let mtu = mock.mtu else {
             return
         }
-        guard let services = services,
-              services.contains(characteristic.service) else {
+        guard let services = services, let characteristicService = characteristic.service,
+              services.contains(characteristicService) else {
             return
         }
         
@@ -1224,8 +1225,8 @@ open class CBMPeripheralMock: CBMPeer, CBMPeripheral {
               let interval = mock.connectionInterval else {
             return
         }
-        guard let services = services,
-              services.contains(descriptor.characteristic.service) else {
+        guard let services = services, let descriptorService = descriptor.characteristic?.service,
+              services.contains(descriptorService) else {
             return
         }
         
@@ -1272,8 +1273,8 @@ open class CBMPeripheralMock: CBMPeer, CBMPeripheral {
               let interval = mock.connectionInterval else {
             return
         }
-        guard let services = services,
-              services.contains(characteristic.service) else {
+        guard let services = services, let characteristicService = characteristic.service,
+              services.contains(characteristicService) else {
             return
         }
         guard enabled != characteristic.isNotifying else {

--- a/CoreBluetoothMock/Classes/CBMServiceTypes.swift
+++ b/CoreBluetoothMock/Classes/CBMServiceTypes.swift
@@ -38,7 +38,7 @@ open class CBMService: CBMAttribute {
     internal var _characteristics: [CBMCharacteristic]?
 
     /// A back-pointer to the peripheral this service belongs to.
-    open internal(set) unowned var peripheral: CBMPeripheral
+    open internal(set) weak var peripheral: CBMPeripheral?
     
     /// The type of the service (primary or secondary).
     open fileprivate(set) var isPrimary: Bool
@@ -152,7 +152,7 @@ open class CBMCharacteristic: CBMAttribute {
     }
 
     /// A back-pointer to the service this characteristic belongs to.
-    open internal(set) var service: CBMService
+    open internal(set) weak var service: CBMService?
     
     /// The properties of the characteristic.
     public let properties: CBMCharacteristicProperties
@@ -256,7 +256,7 @@ open class CBMDescriptor: CBMAttribute {
     }
     
     /// A back-pointer to the characteristic this descriptor belongs to.
-    open internal(set) var characteristic: CBMCharacteristic
+    open internal(set) weak var characteristic: CBMCharacteristic?
 
     /// The value of the descriptor.
     open internal(set) var value: Any?

--- a/Example/nRFBlinky/Models/BlinkyPeripheral.swift
+++ b/Example/nRFBlinky/Models/BlinkyPeripheral.swift
@@ -285,8 +285,8 @@ class BlinkyPeripheral: NSObject, CBPeripheralDelegate {
             return
         }
         if characteristic == buttonCharacteristic {
-            assert(characteristic.service.isPrimary)
-            assert(characteristic.service.peripheral.identifier == basePeripheral.identifier)
+            assert(characteristic.service?.isPrimary ?? false)
+            assert(characteristic.service?.peripheral?.identifier == basePeripheral.identifier)
             assert(characteristic.isNotifying)
             print("Button notifications enabled")
             post(.blinky(self,
@@ -312,7 +312,7 @@ class BlinkyPeripheral: NSObject, CBPeripheralDelegate {
                     //Capture and discover all characteristics for the blinky service
                     assert(service.isPrimary)
                     assert(service.characteristics == nil)
-                    assert(service.peripheral.identifier == peripheral.identifier)
+                    assert(service.peripheral?.identifier == peripheral.identifier)
                     discoverCharacteristicsForBlinkyService(service)
                     return
                 }


### PR DESCRIPTION
This PR makes the `CBMService.peripheral`, `CBMCharacteristic.service` and `CBMDescriptor.characteristic` weak. This is in line with a change in iOS 15. 

**Note:**
Unfortunately, we were not able to keep unowned properties for Xcode 12.5 and older and weak for Xcode 13 and newer. On contrary to the native API, the changes will also apply for older platforms.