### PR TITLE
Connection API fixed: default parameters added, as in native

### DIFF
--- a/CoreBluetoothMock/Classes/CBMCentralManager.swift
+++ b/CoreBluetoothMock/Classes/CBMCentralManager.swift
@@ -104,12 +104,50 @@ public protocol CBMCentralManager: AnyObject {
     @available(iOS 7.0, *)
     func retrieveConnectedPeripherals(withServices serviceUUIDs: [CBMUUID]) -> [CBMPeripheral]
     
+    #if !os(macOS)
     /// Calls `centralManager(:connectionEventDidOccur:for:)` when a connection event
     /// occurs matching any of the given options. Passing nil in the option parameter
     /// clears any prior registered matching options.
     /// - Parameter options: A dictionary specifying connection event options.
-    #if !os(macOS)
     @available(iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     func registerForConnectionEvents(options: [CBMConnectionEventMatchingOption : Any]?)
     #endif
+}
+
+public extension CBMCentralManager {
+    
+    /// Initiates a connection to peripheral. Connection attempts never time out
+    /// and, depending on the outcome, will result in a call to either
+    /// `centralManager(didConnect:)` or `centralManager(didFailToConnect:error:)`.
+    /// Pending attempts are cancelled automatically upon deallocation of peripheral,
+    /// and explicitly via `cancelPeripheralConnection(_:)`.
+    /// - Parameter peripheral: The `CBMPeripheral` to be connected.
+    func connect(_ peripheral: CBMPeripheral) {
+        connect(peripheral, options: nil)
+    }
+    
+    /// Starts scanning for peripherals that are advertising any of the services listed
+    /// in serviceUUIDs. Although strongly discouraged, if serviceUUIDs
+    /// is nil all discovered peripherals will be returned. If the central is
+    /// already scanning with different serviceUUIDs or options, the
+    /// provided parameters will replace them. Applications that have specified the
+    /// `bluetooth-central` background mode are allowed to scan while
+    /// backgrounded, with two caveats: the scan must specify one or more service types
+    /// in serviceUUIDs, and the `CBCentralManagerScanOptionAllowDuplicatesKey`
+    /// scan option will be ignored.
+    /// - Parameter serviceUUIDs: A list of `CBUUID` objects representing the service(s)
+    ///                           to scan for.
+    func scanForPeripherals(withServices serviceUUIDs: [CBMUUID]?) {
+        scanForPeripherals(withServices: serviceUUIDs, options: nil)
+    }
+    
+    #if !os(macOS)
+    /// Calls `centralManager(:connectionEventDidOccur:for:)` when a connection event
+    /// occurs and clears any prior registered matching options.
+    @available(iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+    func registerForConnectionEvents() {
+        registerForConnectionEvents(options: nil)
+    }
+    #endif
+    
 }

--- a/CoreBluetoothMock/Classes/CBMCentralManager.swift
+++ b/CoreBluetoothMock/Classes/CBMCentralManager.swift
@@ -48,67 +48,118 @@ public protocol CBMCentralManager: AnyObject {
     @available(iOS 9.0, *)
     var isScanning: Bool { get }
     
-    /// Returns a boolean value representing the support for the provided features.
-    /// - Parameter features: One or more features you would like to check if supported.
     #if !os(macOS)
+    /// Returns a Boolean that indicates whether the device supports a
+    /// specific set of features.
+    /// - Parameter features: One or more features that you would like to
+    ///                       check for support.
     @available(iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     static func supports(_ features: CBMCentralManager.Feature) -> Bool
     #endif
     
-    /// Starts scanning for peripherals that are advertising any of the services listed
-    /// in serviceUUIDs. Although strongly discouraged, if serviceUUIDs
-    /// is nil all discovered peripherals will be returned. If the central is
-    /// already scanning with different serviceUUIDs or options, the
-    /// provided parameters will replace them. Applications that have specified the
-    /// `bluetooth-central` background mode are allowed to scan while
-    /// backgrounded, with two caveats: the scan must specify one or more service types
-    /// in serviceUUIDs, and the `CBCentralManagerScanOptionAllowDuplicatesKey`
-    /// scan option will be ignored.
+    /// Scans for peripherals that are advertising services.
+    ///
+    /// You can provide an array of CBUUID objects — representing service
+    /// UUIDs — in the serviceUUIDs parameter. When you do, the central
+    /// manager returns only peripherals that advertise the services you
+    /// specify. If the `serviceUUIDs` parameter is nil, this method returns
+    /// all discovered peripherals, regardless of their supported services.
+    ///
+    /// - Note:
+    /// The recommended practice is to populate the `serviceUUIDs`
+    /// parameter rather than leaving it nil.
+    ///
+    /// If the central manager is actively scanning with one set of
+    /// parameters and it receives another set to scan, the new parameters
+    /// override the previous set. When the central manager discovers a
+    /// peripheral, it calls the
+    /// `centralManager(_:didDiscover:advertisementData:rssi:)` method of
+    /// its delegate object.
+    ///
+    /// Your app can scan for Bluetooth devices in the background by
+    /// specifying the bluetooth-central background mode. To do this, your
+    /// app must explicitly scan for one or more services by specifying
+    /// them in the `serviceUUIDs` parameter. The `CBMCentralManager` scan
+    /// option has no effect while scanning in the background.
     /// - Parameters:
-    ///   - serviceUUIDs: A list of `CBUUID` objects representing the service(s)
-    ///                   to scan for.
-    ///   - options: An optional dictionary specifying options for the scan.
+    ///   - serviceUUIDs: An array of `CBMUUID` objects that the app is
+    ///                   interested in. Each `CBMUUID` object represents the
+    ///                   UUID of a service that a peripheral advertises.
+    ///   - options: A dictionary of options for customizing the scan. For
+    ///              available options, see Peripheral Scanning Options.
     func scanForPeripherals(withServices serviceUUIDs: [CBMUUID]?, options: [String : Any]?)
     
-    /// Stops scanning for peripherals.
+    /// Asks the central manager to stop scanning for peripherals.
     func stopScan()
     
-    /// Initiates a connection to peripheral. Connection attempts never time out
-    /// and, depending on the outcome, will result in a call to either
-    /// `centralManager(didConnect:)` or `centralManager(didFailToConnect:error:)`.
-    /// Pending attempts are cancelled automatically upon deallocation of peripheral,
-    /// and explicitly via `cancelPeripheralConnection(_:)`.
+    /// Establishes a local connection to a peripheral.
+    ///
+    /// After successfully establishing a local connection to a peripheral,
+    /// the central manager object calls the `centralManager(_:didConnect:)`
+    /// method of its delegate object. If the connection attempt fails, the
+    /// central manager object calls the
+    /// `centralManager(_:didFailToConnect:error:)` method of its delegate
+    /// object instead. Attempts to connect to a peripheral don’t time out.
+    /// To explicitly cancel a pending connection to a peripheral, call the
+    /// `cancelPeripheralConnection(_:)` method. Deallocating peripheral
+    /// also implicitly calls `cancelPeripheralConnection(_:)`.
     /// - Parameters:
-    ///   - peripheral: The `CBMPeripheral` to be connected.
-    ///   - options: An optional dictionary specifying connection behavior options.
+    ///   - peripheral: The peripheral to which the central is attempting
+    ///                 to connect.
+    ///   - options: A dictionary to customize the behavior of the
+    ///              connection. For available options, see Peripheral
+    ///              Connection Options.
     func connect(_ peripheral: CBMPeripheral, options: [String : Any]?)
     
-    /// Cancels an active or pending connection to peripheral. Note that this
-    /// is non-blocking, and any `CBMPeripheral` commands that are still
-    /// pending to peripheral may or may not complete.
-    /// - Parameter peripheral: A `CBMPeripheral`.
+    /// Cancels an active or pending local connection to a peripheral.
+    ///
+    /// This method is nonblocking, and any `CBMPeripheral` class commands
+    /// that are still pending to peripheral may not complete. Because
+    /// other apps may still have a connection to the peripheral, canceling
+    /// a local connection doesn’t guarantee that the underlying physical
+    /// link is immediately disconnected. From the app’s perspective,
+    /// however, the peripheral is effectively disconnected, and the
+    /// central manager object calls the
+    /// `centralManager(_:didDisconnectPeripheral:error:)` method of its
+    /// delegate object.
+    /// - Parameter peripheral: The peripheral to which the central manager
+    ///                         is either trying to connect or has already
+    ///                         connected.
     func cancelPeripheralConnection(_ peripheral: CBMPeripheral)
     
-    /// Attempts to retrieve the `CBMPeripheral` object(s) with the
-    /// corresponding identifiers.
-    /// - Parameter identifiers: A list of `UUID` objects.
+    /// Returns a list of known peripherals by their identifiers.
+    /// - Parameter identifiers: A list of peripheral identifiers
+    ///                          (represented by NSUUID objects) from which
+    ///                          `CBMPeripheral` objects can be retrieved.
+    /// - Returns: A list of peripherals that the central manager is able
+    ///            to match to the provided identifiers.
     @available(iOS 7.0, *)
     func retrievePeripherals(withIdentifiers identifiers: [UUID]) -> [CBMPeripheral]
     
-    /// Retrieves all peripherals that are connected to the system and implement
-    /// any of the services listed in serviceUUIDs.
-    /// Note that this set can include peripherals which were connected by other
-    /// applications, which will need to be connected locally via
-    /// `connect(peripheral:options:)` before they can be used.
-    /// - Returns: A list of `CBMPeripheral` objects.
+    /// Returns a list of the peripherals connected to the system whose
+    /// services match a given set of criteria.
+    ///
+    /// The list of connected peripherals can include those that other apps
+    /// have connected. You need to connect these peripherals locally using
+    /// the `connect(_:options:)` method before using them.
+    /// - Parameter serviceUUIDs: A list of service UUIDs, represented by
+    ///                           `CBMUUID` objects.
+    /// - Returns: A list of the peripherals that are currently connected
+    ///            to the system and that contain any of the services
+    ///            specified in the `serviceUUID` parameter.
     @available(iOS 7.0, *)
     func retrieveConnectedPeripherals(withServices serviceUUIDs: [CBMUUID]) -> [CBMPeripheral]
     
     #if !os(macOS)
-    /// Calls `centralManager(:connectionEventDidOccur:for:)` when a connection event
-    /// occurs matching any of the given options. Passing nil in the option parameter
-    /// clears any prior registered matching options.
-    /// - Parameter options: A dictionary specifying connection event options.
+    /// Register for an event notification when the central manager makes a
+    /// connection matching the given options.
+    ///
+    /// When the central manager makes a connection that matches the
+    /// options, it calls the delegate’s
+    /// `centralManager(_:connectionEventDidOccur:for:)` method.
+    /// - Parameter options: A dictionary that specifies options for
+    ///                      connection events. See Peripheral Connection
+    ///                      Options for a list of possible options.
     @available(iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     func registerForConnectionEvents(options: [CBMConnectionEventMatchingOption : Any]?)
     #endif
@@ -116,34 +167,63 @@ public protocol CBMCentralManager: AnyObject {
 
 public extension CBMCentralManager {
     
-    /// Initiates a connection to peripheral. Connection attempts never time out
-    /// and, depending on the outcome, will result in a call to either
-    /// `centralManager(didConnect:)` or `centralManager(didFailToConnect:error:)`.
-    /// Pending attempts are cancelled automatically upon deallocation of peripheral,
-    /// and explicitly via `cancelPeripheralConnection(_:)`.
-    /// - Parameter peripheral: The `CBMPeripheral` to be connected.
-    func connect(_ peripheral: CBMPeripheral) {
-        connect(peripheral, options: nil)
-    }
-    
-    /// Starts scanning for peripherals that are advertising any of the services listed
-    /// in serviceUUIDs. Although strongly discouraged, if serviceUUIDs
-    /// is nil all discovered peripherals will be returned. If the central is
-    /// already scanning with different serviceUUIDs or options, the
-    /// provided parameters will replace them. Applications that have specified the
-    /// `bluetooth-central` background mode are allowed to scan while
-    /// backgrounded, with two caveats: the scan must specify one or more service types
-    /// in serviceUUIDs, and the `CBCentralManagerScanOptionAllowDuplicatesKey`
-    /// scan option will be ignored.
-    /// - Parameter serviceUUIDs: A list of `CBUUID` objects representing the service(s)
-    ///                           to scan for.
+    /// Scans for peripherals that are advertising services.
+    ///
+    /// You can provide an array of CBUUID objects — representing service
+    /// UUIDs — in the serviceUUIDs parameter. When you do, the central
+    /// manager returns only peripherals that advertise the services you
+    /// specify. If the `serviceUUIDs` parameter is nil, this method returns
+    /// all discovered peripherals, regardless of their supported services.
+    ///
+    /// - Note:
+    /// The recommended practice is to populate the `serviceUUIDs`
+    /// parameter rather than leaving it nil.
+    ///
+    /// If the central manager is actively scanning with one set of
+    /// parameters and it receives another set to scan, the new parameters
+    /// override the previous set. When the central manager discovers a
+    /// peripheral, it calls the
+    /// `centralManager(_:didDiscover:advertisementData:rssi:)` method of
+    /// its delegate object.
+    ///
+    /// Your app can scan for Bluetooth devices in the background by
+    /// specifying the bluetooth-central background mode. To do this, your
+    /// app must explicitly scan for one or more services by specifying
+    /// them in the `serviceUUIDs` parameter. The `CBMCentralManager` scan
+    /// option has no effect while scanning in the background.
+    /// - Parameters:
+    ///   - serviceUUIDs: An array of `CBMUUID` objects that the app is
+    ///                   interested in. Each `CBMUUID` object represents the
+    ///                   UUID of a service that a peripheral advertises.
     func scanForPeripherals(withServices serviceUUIDs: [CBMUUID]?) {
         scanForPeripherals(withServices: serviceUUIDs, options: nil)
     }
     
+    /// Establishes a local connection to a peripheral.
+    ///
+    /// After successfully establishing a local connection to a peripheral,
+    /// the central manager object calls the `centralManager(_:didConnect:)`
+    /// method of its delegate object. If the connection attempt fails, the
+    /// central manager object calls the
+    /// `centralManager(_:didFailToConnect:error:)` method of its delegate
+    /// object instead. Attempts to connect to a peripheral don’t time out.
+    /// To explicitly cancel a pending connection to a peripheral, call the
+    /// `cancelPeripheralConnection(_:)` method. Deallocating peripheral
+    /// also implicitly calls `cancelPeripheralConnection(_:)`.
+    /// - Parameters:
+    ///   - peripheral: The peripheral to which the central is attempting
+    ///                 to connect.
+    func connect(_ peripheral: CBMPeripheral) {
+        connect(peripheral, options: nil)
+    }
+    
     #if !os(macOS)
-    /// Calls `centralManager(:connectionEventDidOccur:for:)` when a connection event
-    /// occurs and clears any prior registered matching options.
+    /// Register for an event notification when the central manager makes a
+    /// connection matching the given options.
+    ///
+    /// When the central manager makes a connection that matches the
+    /// options, it calls the delegate’s
+    /// `centralManager(_:connectionEventDidOccur:for:)` method.
     @available(iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     func registerForConnectionEvents() {
         registerForConnectionEvents(options: nil)

--- a/CoreBluetoothMock/Classes/CBMCentralManagerFactory.swift
+++ b/CoreBluetoothMock/Classes/CBMCentralManagerFactory.swift
@@ -48,10 +48,10 @@ public class CBMCentralManagerFactory {
     /// - SeeAlso: CBMCentralManagerRestoredStateScanOptionsKey
     public static var simulateStateRestoration: ((_ identifierKey: String) -> [String : Any]?)?
     
+    #if !os(macOS)
     /// Returns a boolean value representing the support for the provided features.
     ///
     /// This method will be called when `supports(:)` method is called.
-    #if !os(macOS)
     @available(iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     public static var simulateFeaturesSupport: ((_ features: CBMCentralManager.Feature) -> Bool)?
     #endif

--- a/CoreBluetoothMock/Classes/CBMPeripheral.swift
+++ b/CoreBluetoothMock/Classes/CBMPeripheral.swift
@@ -32,50 +32,124 @@ import CoreBluetooth
 
 public protocol CBMPeripheral: AnyObject {
     
-    /// The unique, persistent identifier associated with the peer.
+    /// The UUID associated with the peer.
+    ///
+    /// The value of this property represents the unique identifier of the
+    /// peer. The first time a local manager encounters a peer, the system
+    /// assigns the peer a UUID, represented by a new UUID object. Peers
+    /// use UUID instances to identify themselves, instead of by the `CBMUUID`
+    /// objects that identify a peripheral’s services, characteristics, and
+    /// descriptors.
     var identifier: UUID { get }
     
-    /// The delegate object that will receive peripheral events.
+    /// The delegate object specified to receive peripheral events.
+    ///
+    /// For information about how to implement your peripheral delegate,
+    /// see `CBMPeripheralDelegate`.
     var delegate: CBMPeripheralDelegate? { get set }
     
     /// The name of the peripheral.
+    ///
+    /// Use this property to retrieve a human-readable name of the
+    /// peripheral. A peripheral may have two different name types: one
+    /// that the device advertises and another that the device publishes in
+    /// its database as its Bluetooth low energy Generic Access Profile
+    /// (GAP) device name. If a peripheral has both types of names, this
+    /// property returns its GAP device name.
     var name: String? { get }
     
-    /// The current connection state of the peripheral.
+    /// The connection state of the peripheral.
+    ///
+    /// This property represents the current connection state of the
+    /// peripheral. For a list of the possible values, see
+    /// `CBMPeripheralState`.
     var state: CBMPeripheralState { get }
     
-    /// A list of `CBMServiceMock` objects that have been
-    /// discovered on the peripheral.
+    /// A list of a peripheral’s discovered services.
+    ///
+    /// Returns an array of services (represented by `CBMService` objects)
+    /// that successful call to the `discoverServices(_:)` method discovered.
+    /// If you haven’t yet called the `discoverServices(_:)` method to
+    /// discover the services of the peripheral, or if there was an error
+    /// in doing so, the value of this property is nil.
     var services: [CBMService]? { get }
     
-    /// True if the remote device has space to send a write without
-    /// response. If this value is false, the value will be set to
-    /// true after the current writes have been flushed, and
-    /// `peripheralIsReady(toSendWriteWithoutResponse:)` will be called.
+    /// A Boolean value that indicates whether the remote device can send a
+    /// write without a response.
+    ///
+    /// If this value is false, flushing all current writes sets the value
+    /// to true. This also results in a call to the delegate’s
+    /// `peripheralIsReady(toSendWriteWithoutResponse:)`.
     @available(iOS 11.0, tvOS 11.0, watchOS 4.0, *)
     var canSendWriteWithoutResponse: Bool { get }
     
-    /// True if the remote device has been authorized to receive data
-    /// over ANCS (Apple Notification Service Center) protocol.
-    /// If this value is false, the value will be set to true after
-    /// a user authorization occurs and
-    /// `centralManager(_:didUpdateANCSAuthorizationFor:)` will be called.
     #if !os(macOS)
+    /// A Boolean value that indicates if the remote device has
+    /// authorization to receive data over ANCS protocol.
+    ///
+    /// If this value is false, a user authorization sets this value to
+    /// true, which results in a call to the delegate’s
+    /// `centralManager(_:didUpdateANCSAuthorizationFor:)` method.
     @available(iOS 13.0, tvOS 13.0, watchOS 6.0, *)
     var ancsAuthorized: Bool { get }
     #endif
     
-    /// While connected, retrieves the current RSSI of the link.
+    /// Retrieves the current RSSI value for the peripheral while connected
+    /// to the central manager.
+    ///
+    /// On macOS, when you call this method to retrieve the Received Signal
+    /// Strength Indicator (RSSI) of the peripheral while connected to the
+    /// central manager, the peripheral calls the
+    /// `peripheralDidUpdateRSSI(_:error:)` method of its delegate object.
+    /// If retrieving the RSSI value of the peripheral succeeds, you can
+    /// access it through the peripheral’s rssi property.
+    ///
+    /// On iOS and tvOS, when you call this method to retrieve the RSSI of
+    /// the peripheral while connected to the central manager, the
+    /// peripheral calls the `peripheral(_:didReadRSSI:error:)` method of its
+    /// delegate object, which includes the RSSI value as a parameter.
     func readRSSI()
     
-    /// Discovers available service(s) on the peripheral.
+    /// Discovers the specified services of the peripheral.
+    ///
+    /// You can provide an array of `CBUUID` objects — representing service
+    /// UUIDs — in the `serviceUUIDs` parameter. When you do, the peripheral
+    /// returns only the services of the peripheral that match the provided
+    /// UUIDs.
+    ///
+    /// - Note:
+    /// If the `servicesUUIDs` parameter is nil, this method returns
+    /// all of the peripheral’s available services. This is much
+    /// slower than providing an array of service UUIDs to search for.
+    ///
+    /// When the peripheral discovers one or more services, it
+    /// calls the `peripheral(_:didDiscoverServices:):` method of its
+    /// delegate object. After a peripheral discovers services, you
+    /// can access them through the peripheral’s services property.
     /// - Parameter serviceUUIDs: A list of `CBMUUID` objects
     ///                           representing the service types to be
     ///                           discovered. If `nil`, all services
     ///                           will be discovered.
     func discoverServices(_ serviceUUIDs: [CBMUUID]?)
     
-    /// Discovers the specified included service(s) of service.
+    /// Discovers the specified included services of a
+    /// previously-discovered service.
+    ///
+    /// You can provide an array of CBUUID objects — representing included
+    /// service UUIDs — in the includedServiceUUIDs parameter. When you do,
+    /// the peripheral returns only the services of the peripheral that
+    /// match the provided UUIDs.
+    ///
+    /// - Note:
+    /// If the `servicesUUIDs` parameter is nil, this method returns all of
+    /// the peripheral’s available services. This is much slower than
+    /// providing an array of service UUIDs to search for.
+    ///
+    /// When the peripheral discovers one or more included services of the
+    /// specified service, it calls the
+    /// `peripheral(_:didDiscoverIncludedServicesFor:error:)` method of its
+    /// delegate object. After the service discovers its included services,
+    /// you can access them through the service’s includedServices property.
     /// - Parameters:
     ///   - includedServiceUUIDs: A list of `CBMUUID` objects
     ///                           representing the included service types
@@ -87,7 +161,25 @@ public protocol CBMPeripheral: AnyObject {
     func discoverIncludedServices(_ includedServiceUUIDs: [CBMUUID]?,
                                   for service: CBMService)
     
-    /// Discovers the specified characteristic(s) of service.
+    /// Discovers the specified characteristics of a service.
+    ///
+    /// You can provide an array of CBUUID objects—representing
+    /// characteristic UUIDs — in the `characteristicUUIDs` parameter. When
+    /// you do, the peripheral returns only the characteristics of the
+    /// service that match the provided UUIDs. If the `characteristicUUIDs`
+    /// parameter is nil, this method returns all characteristics of the service.
+    ///
+    /// - Note:
+    /// If the characteristicUUIDs parameter is nil, this method returns
+    /// all of the service’s characteristics. This is much slower than
+    /// providing an array of characteristic UUIDs to search for.
+    ///
+    /// When the peripheral discovers one or more characteristics of the
+    /// specified service, it calls the
+    /// `peripheral(_:didDiscoverCharacteristicsFor:error:)` method of its
+    /// delegate object. After the peripheral discovers the service’s
+    /// characteristics, you can access them through the service’s
+    /// characteristics property.
     /// - Parameters:
     ///   - characteristicUUIDs: A list of `CBMUUID` objects
     ///                          representing the characteristic types
@@ -98,61 +190,130 @@ public protocol CBMPeripheral: AnyObject {
     func discoverCharacteristics(_ characteristicUUIDs: [CBMUUID]?,
                                  for service: CBMService)
     
-    /// Discovers the characteristic descriptor(s) of characteristic.
+    /// Discovers the descriptors of a characteristic.
+    ///
+    /// When the peripheral discovers one or more descriptors of the
+    /// specified characteristic, it calls the
+    /// `peripheral(_:didDiscoverDescriptorsFor:error:)` method of its
+    /// delegate object. After the peripheral discovers the descriptors of
+    /// the characteristic, you can access them through the
+    /// characteristic’s descriptors property.
     /// - Parameter characteristic: A GATT characteristic.
     func discoverDescriptors(for characteristic: CBMCharacteristic)
     
-    /// Reads the characteristic value for characteristic.
+    /// Retrieves the value of a specified characteristic.
+    ///
+    /// When you call this method to read the value of a characteristic,
+    /// the peripheral calls the `peripheral(_:didUpdateValueFor:error:)`
+    /// method of its delegate object. If the peripheral successfully reads
+    /// the value of the characteristic, you can access it through the
+    /// characteristic’s value property.
+    ///
+    /// Not all characteristics have a readable value. You can determine
+    /// whether a characteristic’s value is readable by accessing the
+    /// relevant properties of the `CBMCharacteristicProperties` enumeration.
     /// - Parameter characteristic: A GATT characteristic.
     func readValue(for characteristic: CBMCharacteristic)
     
-    /// Reads the descriptor value for descriptor.
+    /// Retrieves the value of a specified characteristic descriptor.
+    ///
+    /// When you call this method to read the value of a characteristic
+    /// descriptor, the peripheral calls the
+    /// `peripheral(_:didUpdateValueFor:error:)` method of its delegate
+    /// object. If the peripheral successfully retrieves the value of the
+    /// characteristic descriptor, you can access it through the
+    /// characteristic descriptor’s value property.
     /// - Parameter descriptor: A GATT descriptor.
     func readValue(for descriptor: CBMDescriptor)
 
-    /// The maximum amount of data, in bytes, that can be sent to a
+    /// The maximum amount of data, in bytes, you can send to a
     /// characteristic in a single write type.
+    /// - Parameter type: The characteristic write type to inspect.
     @available(iOS 9.0, *)
     func maximumWriteValueLength(for type: CBMCharacteristicWriteType) -> Int
     
-    /// Writes value to characteristic's characteristic value.
-    /// If the `.withResponse` type is specified,
-    /// `peripheral(_:didWriteValueForCharacteristic:error:)` is called with the
-    /// result of the write request.
-    /// If the `.withoutResponse` type is specified, and
-    /// `canSendWriteWithoutResponse` is false, the delivery of the data is
-    /// best-effort and may not be guaranteed.
+    /// Writes the value of a characteristic.
+    ///
+    /// When you call this method to write the value of a characteristic,
+    /// the peripheral calls the `peripheral(_:didWriteValueFor:error:)`
+    /// method of its delegate object only if you specified the write type
+    /// as `CBMCharacteristicWriteType.withResponse`. The response you
+    /// receive through the `peripheral(_:didWriteValueFor:error:)`
+    /// delegate method indicates whether the write was successful; if the
+    /// write failed, it details the cause of the failure in an error.
+    ///
+    /// On the other hand, if you specify the write type as
+    /// `CBCharacteristicWriteType.withoutResponse`, Core Bluetooth
+    /// attempts to write the value but doesn’t guarantee success. If the
+    /// write doesn’t succeed in this case, you aren’t notified and you
+    /// don’t receive an error indicating the cause of the failure.
+    ///
+    /// Use the `write` and `writeWithoutResponse` members of the
+    /// characteristic’s properties enumeration to determine which kinds of
+    /// writes you can perform.
+    ///
+    /// This method copies the data passed into the data parameter, and you
+    /// can dispose of it after the method returns.
     /// - Parameters:
     ///   - data: The value to write.
-    ///   - characteristic: The characteristic whose characteristic value will
-    ///                     be written.
-    ///   - type: The type of write to be executed.
+    ///   - characteristic: The characteristic containing the value to write.
+    ///   - type: The type of write to execute. For a list of the possible
+    ///           types of writes to a characteristic’s value, see
+    ///           `CBMCharacteristicWriteType`.
     func writeValue(_ data: Data, for characteristic: CBMCharacteristic,
                     type: CBMCharacteristicWriteType)
     
-    /// Writes data to descriptor's value. Client characteristic
-    /// configuration descriptors cannot be written using this method, and
-    /// should instead use `setNotifyValue(:forCharacteristic:)`.
+    /// Writes the value of a characteristic descriptor.
+    ///
+    /// When you call this method to write the value of a characteristic
+    /// descriptor, the peripheral calls the
+    /// `peripheral(_:didWriteValueFor:error:)` method of its delegate
+    /// object.
+    ///
+    /// This method copies the data passed into the data parameter, and you
+    /// can dispose of it after the method returns.
+    ///
+    /// You can’t use this method to write the value of a client
+    /// configuration descriptor (represented by the
+    /// `CBUUIDClientCharacteristicConfigurationString` constant), which
+    /// describes the configuration of notification or indications for a
+    /// characteristic’s value. If you want to manage notifications or
+    /// indications for a characteristic’s value, you must use the
+    /// `setNotifyValue(_:for:)` method instead.
     /// - Parameters:
     ///   - data: The value to write.
-    ///   - descriptor: A GATT characteristic descriptor.
+    ///   - descriptor: The descriptor containing the value to write.
     func writeValue(_ data: Data, for descriptor: CBMDescriptor)
 
-    /// Enables or disables notifications/indications for the characteristic
-    /// value of characteristic. If characteristic allows both,
-    /// notifications will be used. When notifications/indications are enabled,
-    /// updates to the characteristic value will be received via delegate method
-    /// `peripheral(:didUpdateValueForCharacteristic:error:)`. Since it is the
-    /// peripheral that chooses when to send an update, the application should
-    /// be prepared to handle them as long as notifications/indications remain
-    /// enabled.
+    /// Sets notifications or indications for the value of a specified characteristic.
+    ///
+    /// When you enable notifications for the characteristic’s value, the
+    /// peripheral calls the
+    /// `peripheral(_:didUpdateNotificationStateFor:error:)` method of its
+    /// delegate object to indicate if the action succeeded. If successful,
+    /// the peripheral then calls the
+    /// `peripheral(_:didUpdateValueFor:error:)` method of its delegate
+    /// object whenever the characteristic value changes. Because the
+    /// peripheral chooses when it sends an update, your app should prepare
+    /// to handle them as long as notifications or indications remain
+    /// enabled. If the specified characteristic’s configuration allows
+    /// both notifications and indications, calling this method enables
+    /// notifications only. You can disable notifications and indications
+    /// for a characteristic’s value by calling this method with the
+    /// enabled parameter set to false.
     /// - Parameters:
-    ///   - enabled: Whether or not notifications/indications should be enabled.
-    ///   - characteristic: The characteristic containing the client
-    ///                     characteristic configuration descriptor.
+    ///   - enabled: Boolean value that indicates whether to receive
+    ///              notifications or indications whenever the
+    ///              characteristic’s value changes. true if you want to
+    ///              enable notifications or indications for the
+    ///              characteristic’s value. false if you don’t want to
+    ///              receive notifications or indications whenever the
+    ///              characteristic’s value changes.
+    ///   - characteristic: The specified characteristic.
     func setNotifyValue(_ enabled: Bool, for characteristic: CBMCharacteristic)
 
-    /// Attempt to open an L2CAP channel to the peripheral using the supplied PSM.
+    /// Attempts to open an L2CAP channel to the peripheral using the
+    /// supplied Protocol/Service Multiplexer (PSM).
     /// - Parameter PSM: The PSM of the channel to open.
     #if !os(macOS)
     @available(iOS 11.0, tvOS 11.0, watchOS 4.0, *)

--- a/Example/nRFBlinky/Models/BlinkyManager.swift
+++ b/Example/nRFBlinky/Models/BlinkyManager.swift
@@ -84,7 +84,7 @@ class BlinkyManager {
         }
         connectedBlinky = blinky
         print("Connecting to Blinky device...")
-        centralManager.connect(blinky.basePeripheral, options: nil)
+        centralManager.connect(blinky.basePeripheral)
     }
 
     /// Cancels existing or pending connection.


### PR DESCRIPTION
This PR fixes #47. It also refreshed the comments for `CBMPeripheral` and `CBMCentralManager` to match their native counterparts.