### PR TITLE
Support for authorization added

### DIFF
--- a/CoreBluetoothMock/Classes/CBMCentralManagerFactory.swift
+++ b/CoreBluetoothMock/Classes/CBMCentralManagerFactory.swift
@@ -31,30 +31,12 @@
 import CoreBluetooth
 
 /// The factory that instantiates the `CBMCentralManager` object.
+///
 /// The factory may be used to automatically instantiate either a native
 /// or mock implementation based on the environment. You may also
 /// instantiate the `CBMCentralManagerMock` or `CBMCentralManagerNative` without
 /// using this factory.
 public class CBMCentralManagerFactory {
-    
-    /// This simulation method is called when a mock central manager was
-    /// created with an option to restore the state
-    /// (`CBMCentralManagerOptionRestoreIdentifierKey`).
-    ///
-    /// The returned map, if not <i>nil</i>, will be passed to
-    /// `centralManager(:willRestoreState:)` before creation.
-    /// - SeeAlso: CBMCentralManagerRestoredStatePeripheralsKey
-    /// - SeeAlso: CBMCentralManagerRestoredStateScanServicesKey
-    /// - SeeAlso: CBMCentralManagerRestoredStateScanOptionsKey
-    public static var simulateStateRestoration: ((_ identifierKey: String) -> [String : Any]?)?
-    
-    #if !os(macOS)
-    /// Returns a boolean value representing the support for the provided features.
-    ///
-    /// This method will be called when `supports(:)` method is called.
-    @available(iOS 13.0, tvOS 13.0, watchOS 6.0, *)
-    public static var simulateFeaturesSupport: ((_ features: CBMCentralManager.Feature) -> Bool)?
-    #endif
     
     /// Returns the implementation of `CBCentralManager`, depending on the environment.
     /// On a simulator, or when the `forceMock` flag is enabled, the mock

--- a/CoreBluetoothMock/Classes/CBMCentralManagerNative.swift
+++ b/CoreBluetoothMock/Classes/CBMCentralManagerNative.swift
@@ -30,9 +30,7 @@
 
 import CoreBluetooth
 
-public class CBMCentralManagerNative: NSObject, CBMCentralManager {
-    public weak var delegate: CBMCentralManagerDelegate?
-    
+public class CBMCentralManagerNative: CBMCentralManager {
     private var manager: CBCentralManager!
     private var wrapper: CBCentralManagerDelegate!
     private var peripherals: [UUID : CBMPeripheralNative] = [:]
@@ -132,18 +130,28 @@ public class CBMCentralManagerNative: NSObject, CBMCentralManager {
         }
     }
     
-    public var state: CBMManagerState {
+    public override var state: CBMManagerState {
         return CBMManagerState(rawValue: manager.state.rawValue) ?? .unknown
     }
     
     @available(iOS 9.0, *)
-    public var isScanning: Bool {
+    public override var isScanning: Bool {
         return manager.isScanning
+    }
+    
+    @available(iOS, introduced: 13.0, deprecated: 13.1)
+    public override var authorization: CBMManagerAuthorization {
+        return manager.authorization
+    }
+    
+    @available(iOS 13.1, *)
+    public override class var authorization: CBMManagerAuthorization {
+        return CBCentralManager.authorization
     }
     
     #if !os(macOS)
     @available(iOS 13.0, tvOS 13.0, watchOS 6.0, *)
-    public static func supports(_ features: CBMCentralManager.Feature) -> Bool {
+    public override class func supports(_ features: CBMCentralManager.Feature) -> Bool {
         return CBCentralManager.supports(features)
     }
     #endif
@@ -174,29 +182,29 @@ public class CBMCentralManagerNative: NSObject, CBMCentralManager {
         self.delegate = delegate
     }
     
-    public func scanForPeripherals(withServices serviceUUIDs: [CBMUUID]?,
-                                   options: [String : Any]?) {
+    public override func scanForPeripherals(withServices serviceUUIDs: [CBMUUID]?,
+                                            options: [String : Any]?) {
         manager.scanForPeripherals(withServices: serviceUUIDs, options: options)
     }
     
-    public func stopScan() {
+    public override func stopScan() {
         manager.stopScan()
     }
     
-    public func connect(_ peripheral: CBMPeripheral, options: [String : Any]?) {
+    public override func connect(_ peripheral: CBMPeripheral, options: [String : Any]?) {
         if let peripheral = peripherals[peripheral.identifier] {
             manager.connect(peripheral.peripheral, options: options)
         }
     }
     
-    public func cancelPeripheralConnection(_ peripheral: CBMPeripheral) {
+    public override func cancelPeripheralConnection(_ peripheral: CBMPeripheral) {
         if let peripheral = peripherals[peripheral.identifier] {
             manager.cancelPeripheralConnection(peripheral.peripheral)
         }
     }
     
     @available(iOS 7.0, *)
-    public func retrievePeripherals(withIdentifiers identifiers: [UUID]) -> [CBMPeripheral] {
+    public override func retrievePeripherals(withIdentifiers identifiers: [UUID]) -> [CBMPeripheral] {
         let retrievedPeripherals = manager.retrievePeripherals(withIdentifiers: identifiers)
         retrievedPeripherals
             .filter { peripherals[$0.identifier] == nil }
@@ -207,7 +215,7 @@ public class CBMCentralManagerNative: NSObject, CBMCentralManager {
     }
     
     @available(iOS 7.0, *)
-    public func retrieveConnectedPeripherals(withServices serviceUUIDs: [CBMUUID]) -> [CBMPeripheral] {
+    public override func retrieveConnectedPeripherals(withServices serviceUUIDs: [CBMUUID]) -> [CBMPeripheral] {
         let retrievedPeripherals = manager.retrieveConnectedPeripherals(withServices: serviceUUIDs)
         retrievedPeripherals
             .filter { peripherals[$0.identifier] == nil }
@@ -219,7 +227,7 @@ public class CBMCentralManagerNative: NSObject, CBMCentralManager {
     
     #if !os(macOS)
     @available(iOS 13.0, tvOS 13.0, watchOS 6.0, *)
-    public func registerForConnectionEvents(options: [CBMConnectionEventMatchingOption : Any]? = nil) {
+    public override func registerForConnectionEvents(options: [CBMConnectionEventMatchingOption : Any]? = nil) {
         manager.registerForConnectionEvents(options: options)
     }
     #endif

--- a/CoreBluetoothMock/Classes/CBMManagerTypes.swift
+++ b/CoreBluetoothMock/Classes/CBMManagerTypes.swift
@@ -45,9 +45,13 @@ public enum CBMManagerState: Int {
     case poweredOn
 }
 
-// disabled for Xcode 12.5 beta
-//public typealias CBMPeer = CBPeer
-//public typealias CBMAttribute = CBAttribute
+// In Xcode 12.5 the initializers of CBPeer and CBAttribute
+// became private, therefore they cannot be user. A local
+// counterparts have been created in the library.
+// https://github.com/NordicSemiconductor/IOS-CoreBluetooth-Mock/issues/33
+//
+// public typealias CBMPeer = CBPeer
+// public typealias CBMAttribute = CBAttribute
 public typealias CBMUUID = CBUUID
 public typealias CBMError = CBError
 public typealias CBMATTError = CBATTError

--- a/CoreBluetoothMock/Classes/CBMManagerTypes.swift
+++ b/CoreBluetoothMock/Classes/CBMManagerTypes.swift
@@ -64,6 +64,8 @@ public typealias CBMCharacteristicProperties = CBCharacteristicProperties
 public typealias CBML2CAPPSM = CBL2CAPPSM
 @available(iOS 11.0, tvOS 11.0, watchOS 4.0, *)
 public typealias CBML2CAPChannel = CBL2CAPChannel
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+public typealias CBMManagerAuthorization = CBManagerAuthorization
 
 public let CBMCentralManagerScanOptionAllowDuplicatesKey = CBCentralManagerScanOptionAllowDuplicatesKey
 public let CBMCentralManagerOptionShowPowerAlertKey = CBCentralManagerOptionShowPowerAlertKey

--- a/Example/nRFBlinky/AppDelegate.swift
+++ b/Example/nRFBlinky/AppDelegate.swift
@@ -50,7 +50,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             // Setup the CoreBluetoothMock in debug mode. The mock central manager
             // will be used by UI tests.
             if #available(iOS 13.0, *) {
-                CBMCentralManagerFactory.simulateFeaturesSupport = { features in
+                // Example how the authorization can be set and changed.
+                /*
+                CBMCentralManagerMock.simulateAuthorization(.notDetermined)
+                DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(4)) {
+                    CBMCentralManagerMock.simulateAuthorization(.allowedAlways)
+                }
+                */
+                CBMCentralManagerMock.simulateFeaturesSupport = { features in
                     return features.isSubset(of: .extendedScanAndConnect)
                 }
             }

--- a/Example/nRFBlinky/ViewControllers/ScannerView/ScannerTableViewController.swift
+++ b/Example/nRFBlinky/ViewControllers/ScannerView/ScannerTableViewController.swift
@@ -55,7 +55,6 @@ class ScannerTableViewController: UITableViewController {
             if state == .poweredOn {
                 self.startScan()
             } else {
-                print("Central is not powered on")
                 self.activityIndicator.stopAnimating()
             }
         }


### PR DESCRIPTION
This PR fixes #46.

However, it implement this feature some **breaking changes** had to be made:
- `CBMCentralManager` was refactored from a *protocol* to a *class* with internal init. This was required so the type methods (`CBMCentralManager.authorization` and `CBMCentralManager.supports(:)`) could be called on the main manager without the need of specifying mock or native manager. 

    **Note:** The behavior of those methods is not trivial. If simulated values were set in `CBMCentralManagerMock.simulateAuthorization(:)` and `CBMCentralManagerMock.simulateFeatureSupport`, the above-mentioned methods will return simulated values. Otherwise, the native implementation will be returned. To always get native implementation use `CBMCentralManagerNative.authorization` and `CBMCentralManagerNative.supports(:)`. On the other hand, to always get mock values, use `CBMCentralManagerMock.authorization` and `CBMCentralManagerMock.supports(:)`.
- `simulateStateRestoration` and `simulateFeaturesSupport` were moved from `CBMCentralManagerFactory` to `CBMCentralManagerMock`. This groups all the `simulate...` methods together. That was not required, but I think the API is now more clear.
- A new static method `simulateAuthorization(:)` was added to `CBMCentralManagerMock`. It's available from iOS 13.0. By default, the mock manager has authorization `.allowedAlways`. This method allows to set different values. Other values will cause all the `CBMCentralManager` to transition to `CBMManagerState.unauthorized` state.