### PR TITLE
Allowing extending CBMCentralManager

### DIFF
--- a/CoreBluetoothMock/Classes/CBMCentralManager.swift
+++ b/CoreBluetoothMock/Classes/CBMCentralManager.swift
@@ -32,8 +32,39 @@ import CoreBluetooth
 
 open class CBMCentralManager: NSObject {
     
-    internal override init() {
-        // Use CBMCentralManagerFactory.instance(...) instead.
+    /// A dummy initializer that allows overriding `CBMCentralManager` class and also
+    /// gives a warninig when trying to migrate from native `CBCentralManager`
+    /// to `CBMCentralManager`. This method does nothing.
+    ///
+    /// If you need to create your own implementation of central manager, call it. See also
+    /// [Issue #55](https://github.com/NordicSemiconductor/IOS-CoreBluetooth-Mock/issues/55).
+    ///
+    /// If you migrated to CoreBluetooth Mock and are getting an error with
+    /// instantiating a `CBMCentralBanager` instance, use
+    /// `CBMCentalManagerFactory.instance(...)` instead.
+    ///
+    /// See [documentation](https://github.com/NordicSemiconductor/IOS-CoreBluetooth-Mock/#other-required-changes).
+    /// - Parameter dummy: This can be anything.
+    public init(_ dummy: Bool) {
+        // pancakes
+        //
+        //  his.appetite is growing.back
+        //  he.asked(for: pancakes) - making.them(right.now,
+        //  with: apple.slices, the: favourite.kind)
+        //
+        //  [ 91: this.morning, 85: the.night ]
+        //  ( 89, 84, 86, 90-fine )
+        //  [ O₂, O₂, i.fear, me.too ]
+        //
+        //  literal.reality && virtual.care
+        //  new.fermi.paradox(no: matter.what.I(cut:
+        //  the:drake:equation:with:), no: aliens(with: cure))(
+        //
+        //  you.know, these.days, hospitals.and.all,
+        //  but: 91 > 85, the.appetite is back,
+        //  and: I've.made.him.pancakes(of: his.favourite.kind))
+        //
+        // in Swift, by siejkowski, https://swiftpoetry.com/pancakes/
     }
     
     #if !os(macOS)

--- a/CoreBluetoothMock/Classes/CBMCentralManagerMock.swift
+++ b/CoreBluetoothMock/Classes/CBMCentralManagerMock.swift
@@ -163,12 +163,21 @@ open class CBMCentralManagerMock: CBMCentralManager {
             NSLog("Warning: No simulated peripherals. " +
                   "Call simulatePeripherals(:) before creating central manager")
         }
-        // Let's say initialization takes 10 ms. Less or more.
-        let delay: DispatchTimeInterval = .milliseconds(isSimple ? 0 : 10)
-        queue.asyncAfter(deadline: .now() + delay) { [weak self] in
-            if let self = self {
-                CBMCentralManagerMock.managers.append(WeakRef(self))
-                self.delegate?.centralManagerDidUpdateState(self)
+        if isSimple {
+            CBMCentralManagerMock.managers.append(WeakRef(self))
+            queue.async { [weak self] in
+                if let self = self {
+                    self.delegate?.centralManagerDidUpdateState(self)
+                }
+            }
+        } else {
+            // Let's say initialization takes 10 ms. Less or more.
+            let delay: DispatchTimeInterval = .milliseconds(10)
+            queue.asyncAfter(deadline: .now() + delay) { [weak self] in
+                if let self = self {
+                    CBMCentralManagerMock.managers.append(WeakRef(self))
+                    self.delegate?.centralManagerDidUpdateState(self)
+                }
             }
         }
     }

--- a/CoreBluetoothMock/Classes/CBMCentralManagerNative.swift
+++ b/CoreBluetoothMock/Classes/CBMCentralManagerNative.swift
@@ -156,24 +156,26 @@ public class CBMCentralManagerNative: CBMCentralManager {
     }
     #endif
     
-    public override init() {
-        super.init()
+    public init() {
+        super.init(true)
         self.wrapper = CBMCentralManagerDelegateWrapper(self)
         self.manager = CBCentralManager()
         self.manager.delegate = wrapper
     }
     
-    public init(delegate: CBMCentralManagerDelegate?, queue: DispatchQueue?) {
-        super.init()
+    public init(delegate: CBMCentralManagerDelegate?,
+                queue: DispatchQueue?) {
+        super.init(true)
         self.wrapper = CBMCentralManagerDelegateWrapper(self)
         self.manager = CBCentralManager(delegate: wrapper, queue: queue)
         self.delegate = delegate
     }
     
     @available(iOS 7.0, *)
-    public init(delegate: CBMCentralManagerDelegate?, queue: DispatchQueue?,
+    public init(delegate: CBMCentralManagerDelegate?,
+                queue: DispatchQueue?,
                 options: [String : Any]?) {
-        super.init()
+        super.init(true)
         let restoration = options?[CBMCentralManagerOptionRestoreIdentifierKey] != nil
         self.wrapper = restoration ?
             CBMCentralManagerDelegateWrapperWithRestoration(self) :

--- a/CoreBluetoothMock/Classes/CBMManagerTypes.swift
+++ b/CoreBluetoothMock/Classes/CBMManagerTypes.swift
@@ -79,10 +79,6 @@ public let CBMConnectPeripheralOptionRequiresANCS = CBConnectPeripheralOptionReq
 public let CBMCentralManagerRestoredStatePeripheralsKey  = CBCentralManagerRestoredStatePeripheralsKey
 public let CBMCentralManagerRestoredStateScanServicesKey = CBCentralManagerRestoredStateScanServicesKey
 public let CBMCentralManagerRestoredStateScanOptionsKey  = CBCentralManagerRestoredStateScanOptionsKey
-/// When a `CBMCentralManagerMock` is created with this option, the 10ms delay, which is
-/// normally required for the manager to be initialilze will not be used. Instead, the
-/// manager will be ready immediately.
-public let CBMCentralManagerSimpleMockKey                = "CBMCentralManagerSimpleMockKey"
 
 public let CBMAdvertisementDataLocalNameKey             = CBAdvertisementDataLocalNameKey
 public let CBMAdvertisementDataServiceUUIDsKey          = CBAdvertisementDataServiceUUIDsKey

--- a/CoreBluetoothMock/Classes/CBMManagerTypes.swift
+++ b/CoreBluetoothMock/Classes/CBMManagerTypes.swift
@@ -79,6 +79,10 @@ public let CBMConnectPeripheralOptionRequiresANCS = CBConnectPeripheralOptionReq
 public let CBMCentralManagerRestoredStatePeripheralsKey  = CBCentralManagerRestoredStatePeripheralsKey
 public let CBMCentralManagerRestoredStateScanServicesKey = CBCentralManagerRestoredStateScanServicesKey
 public let CBMCentralManagerRestoredStateScanOptionsKey  = CBCentralManagerRestoredStateScanOptionsKey
+/// When a `CBMCentralManagerMock` is created with this option, the 10ms delay, which is
+/// normally required for the manager to be initialilze will not be used. Instead, the
+/// manager will be ready immediately.
+public let CBMCentralManagerSimpleMockKey                = "CBMCentralManagerSimpleMockKey"
 
 public let CBMAdvertisementDataLocalNameKey             = CBAdvertisementDataLocalNameKey
 public let CBMAdvertisementDataServiceUUIDsKey          = CBAdvertisementDataServiceUUIDsKey


### PR DESCRIPTION
This PR tries to fix #55 by allowing `CBMCentralManager` to be extended by a custom manager.

I had the following goals when adding the change:
1. I wanted `CBMCentralManager` to stay a *class*, not a *protocol*. This allows calling `CBMCentralManager.supports(...)` and other type methods without the need of specifying which manager should be used.
2. I didn't want to touch the delegates, as that would required changes in users' code.

Therefore, this PR makes the following changes:
1. The `CBMCentralManager` is open, and can be extended by 3rd parties. A new dummy `init(dummy:Bool)` initiator has been added just to force the compiler to show an error when migrating from native `CBCentralManager` to `CBMCentralManger` implementation.
2. The 10 ms delay when initializing `CBMCentralManagerMock` has been removed. The initialization is still asynchronous, but immediate. This should speed up tests.