### PR TITLE
Allowing retrieving peripherals with identifiers

### DIFF
--- a/CoreBluetoothMock/Classes/CBMCentralManagerMock.swift
+++ b/CoreBluetoothMock/Classes/CBMCentralManagerMock.swift
@@ -488,6 +488,8 @@ open class CBMCentralManagerMock: CBMCentralManager {
         guard mock.proximity != .outOfRange else {
             return
         }
+        // The device has been scanned and cached.
+        mock.isKnown = true
         guard !mock.isConnected || mock.isAdvertisingWhenConnected else {
             return
         }
@@ -567,7 +569,7 @@ open class CBMCentralManagerMock: CBMCentralManager {
     }
     
     open override func connect(_ peripheral: CBMPeripheral,
-                        options: [String : Any]?) {
+                               options: [String : Any]?) {
         // Central manager must be in powered on state.
         guard ensurePoweredOn() else { return }
         if let o = options, !o.isEmpty {
@@ -618,13 +620,9 @@ open class CBMCentralManagerMock: CBMCentralManager {
         guard ensurePoweredOn() else { return [] }
         // Get the peripherals already known to this central manager.
         let localPeripherals = peripherals[identifiers]
-        // If all were found, return them.
-        if localPeripherals.count == identifiers.count {
-            return localPeripherals
-        }
+        // Also, look for them among other managers, and copy them to the local
+        // manager.
         let missingIdentifiers = identifiers.filter { peripherals[$0] == nil }
-        // Otherwise, we need to look for them among other managers, and
-        // copy them to the local manager.
         let peripheralsKnownByOtherManagers = missingIdentifiers
             .flatMap { i in
                 CBMCentralManagerMock.managers
@@ -634,8 +632,21 @@ open class CBMCentralManagerMock: CBMCentralManager {
         peripheralsKnownByOtherManagers.forEach {
             peripherals[$0.identifier] = $0
         }
+        // Peripherals that have not been scanned by any manager, but have been
+        // cached by the system and can be retrieved.
+        let stillMissingIdentifiers = identifiers.filter { peripherals[$0] == nil }
+        let peripheralsCached = CBMCentralManagerMock.peripherals
+            // Get only cached peripherals.
+            .filter { $0.isKnown }
+            // Search for those that are still missing.
+            .filter { stillMissingIdentifiers.contains($0.identifier) }
+            // Create a local copy.
+            .map { CBMPeripheralMock(basedOn: $0, by: self) }
+        peripheralsCached.forEach {
+            peripherals[$0.identifier] = $0
+        }
         // Return them in the same order as requested, some may be missing.
-        return (localPeripherals + peripheralsKnownByOtherManagers)
+        return (localPeripherals + peripheralsKnownByOtherManagers + peripheralsCached)
             .sorted {
                 let firstIndex = identifiers.firstIndex(of: $0.identifier)!
                 let secondIndex = identifiers.firstIndex(of: $1.identifier)!


### PR DESCRIPTION
This PR is meant to solve #45. It has to be rebased to *develop* after merging #56.

Changes:
1. A new field `isKnown` has been added to `CBMPeripheralSpec` class. It may be set to *true* initially using `CBMPeripheralSpec.Builder.allowForRetrieval()`, later using `simulateCached()`, and is set *true* automatically when the peripheral is scanned and is in range.
2. A known (cached) device can be retrieved using `CBMCentralManagerMock.retrievePeripherals(withIdentifiers:)`. This method should create a `CBMPeripheralMock` instance per each matching identifier.