### PR TITLE
Support for duplicate services

### DIFF
--- a/CoreBluetoothMock/Classes/CBMAttributes.swift
+++ b/CoreBluetoothMock/Classes/CBMAttributes.swift
@@ -342,6 +342,42 @@ open class CBMClientCharacteristicConfigurationDescriptorMock: CBMDescriptorMock
 
 public typealias CBMCCCDescriptorMock = CBMClientCharacteristicConfigurationDescriptorMock
 
+// MARK: - Utilities
+
+internal extension Array where Element == CBMServiceMock {
+    
+    func find(mockOf service: CBMService) -> CBMServiceMock? {
+        return first { $0.identifier == service.identifier }
+    }
+    
+    func find(mockOf characteristic: CBMCharacteristic) -> CBMCharacteristicMock? {
+        guard let service = characteristic.optionalService,
+              let mockService = find(mockOf: service),
+              let mockCharacteristic = mockService.characteristics?.first(where: {
+                $0.identifier == characteristic.identifier
+              }) else {
+            return nil
+        }
+        return mockCharacteristic as? CBMCharacteristicMock
+    }
+    
+    func find(mockOf descriptor: CBMDescriptor) -> CBMDescriptorMock? {
+        guard let characteristic = descriptor.optionalCharacteristic,
+              let service = characteristic.optionalService,
+              let mockService = find(mockOf: service),
+              let mockCharacteristic = mockService.characteristics?.first(where: {
+                $0.identifier == characteristic.identifier
+              }),
+              let mockDescriptor = mockCharacteristic.descriptors?.first(where: {
+                $0.identifier == descriptor.identifier
+              }) else {
+            return nil
+        }
+        return mockDescriptor as? CBMDescriptorMock
+    }
+    
+}
+
 // MARK: - Mocking uninitialized objects
 
 fileprivate let uninitializedPeriperheral   = CBMPeripheralUninitialized()

--- a/CoreBluetoothMock/Classes/CBMAttributes.swift
+++ b/CoreBluetoothMock/Classes/CBMAttributes.swift
@@ -118,30 +118,19 @@ internal class CBMServiceNative: CBMService {
 }
 
 open class CBMServiceMock: CBMService {
-
-    open override var includedServices: [CBMService]? {
-        set { _includedServices = newValue }
-        get { return _includedServices }
-    }
-
-    open override var characteristics: [CBMCharacteristic]? {
-        set { _characteristics = newValue }
-        get { return _characteristics }
-    }
     
     /// Returns a service, initialized with a service type and UUID.
     /// - Parameters:
     ///   - uuid: The Bluetooth UUID of the service.
     ///   - isPrimary: The type of the service (primary or secondary).
+    ///   - includedServices: Optional list of included services.
     ///   - characteristics: Optional list of characteristics.
     public init(type uuid: CBMUUID, primary isPrimary: Bool,
+                includedService: CBMServiceMock...,
                 characteristics: CBMCharacteristicMock...) {
         super.init(type: uuid, primary: isPrimary)
-        self.characteristics = characteristics
-    }
-    
-    open func contains(_ characteristic: CBMCharacteristicMock) -> Bool {
-        return _characteristics?.contains(characteristic) ?? false
+        self._includedServices = includedService
+        self._characteristics = characteristics
     }
     
     open override func isEqual(_ object: Any?) -> Bool {

--- a/CoreBluetoothMock/Classes/CBMAttributes.swift
+++ b/CoreBluetoothMock/Classes/CBMAttributes.swift
@@ -245,10 +245,6 @@ open class CBMCharacteristicMock: CBMCharacteristic {
         self.descriptors = descriptors
     }
     
-    open func contains(_ descriptor: CBMDescriptor) -> Bool {
-        return _descriptors?.contains(descriptor) ?? false
-    }
-    
     open override func isEqual(_ object: Any?) -> Bool {
         if let other = object as? CBMCharacteristicMock {
             return identifier == other.identifier

--- a/CoreBluetoothMock/Classes/CBMCentralManagerMock.swift
+++ b/CoreBluetoothMock/Classes/CBMCentralManagerMock.swift
@@ -307,6 +307,7 @@ open class CBMCentralManagerMock: CBMCentralManager {
         }
         peripheral.services = newServices
 
+        // If there are no connected devices, we're done.
         guard peripheral.virtualConnections > 0 else {
             return
         }
@@ -907,7 +908,7 @@ open class CBMPeripheralMock: CBMPeer, CBMPeripheral {
         }
         
         // Keep only services that hadn't changed.
-        services = services!
+        services = oldServices
             .filter { service in
                 mock.services!.contains(where: {
                     $0.identifier == service.identifier

--- a/CoreBluetoothMock/Classes/CBMCentralManagerMock.swift
+++ b/CoreBluetoothMock/Classes/CBMCentralManagerMock.swift
@@ -963,7 +963,7 @@ open class CBMPeripheralMock: CBMPeer, CBMPeripheral {
         guard state == .connected,
               let delegate = mock.connectionDelegate,
               let interval = mock.connectionInterval,
-              let allServices = mock.services else {
+              let mockServices = mock.services else {
             return
         }
         
@@ -972,7 +972,7 @@ open class CBMPeripheralMock: CBMPeer, CBMPeripheral {
         case .success:
             services = services ?? []
             let initialSize = services!.count
-            services = services! + allServices
+            services = services! + mockServices
                 // Filter all device services that match given list (if set).
                 .filter { serviceUUIDs?.contains($0.uuid) ?? true }
                 // Filter those of them, that are not already in discovered services.
@@ -1006,27 +1006,21 @@ open class CBMPeripheralMock: CBMPeer, CBMPeripheral {
         guard state == .connected,
               let delegate = mock.connectionDelegate,
               let interval = mock.connectionInterval,
-              let allServices = mock.services else {
-            return
-        }
-        guard let services = services, services.contains(service),
-              let originalService = allServices.first(where: {
-                  $0.identifier == service.identifier
-              }) else {
-            return
-        }
-        guard let originalIncludedServices = originalService.includedServices else {
+              let services = services, services.contains(service),
+              let mockServices = mock.services,
+              let mockService = mockServices.find(mockOf: service),
+              let mockIncludedServices = mockService.includedServices else {
             return
         }
         
         switch delegate.peripheral(mock,
                                    didReceiveIncludedServiceDiscoveryRequest: includedServiceUUIDs,
-                                   for: service as! CBMServiceMock) {
+                                   for: mockService) {
         case .success:
             service._includedServices = service._includedServices ?? []
             let initialSize = service._includedServices!.count
             service._includedServices = service._includedServices! +
-                originalIncludedServices
+                mockIncludedServices
                     // Filter all included service that match given list (if set).
                     .filter { includedServiceUUIDs?.contains($0.uuid) ?? true }
                     // Filter those of them, that are not already in discovered services.
@@ -1065,27 +1059,21 @@ open class CBMPeripheralMock: CBMPeer, CBMPeripheral {
         guard state == .connected,
               let delegate = mock.connectionDelegate,
               let interval = mock.connectionInterval,
-              let allServices = mock.services else {
-            return
-        }
-        guard let services = services, services.contains(service),
-              let originalService = allServices.first(where: {
-                  $0.identifier == service.identifier
-              }) else {
-            return
-        }
-        guard let originalCharacteristics = originalService.characteristics else {
+              let services = services, services.contains(service),
+              let mockServices = mock.services,
+              let mockService = mockServices.find(mockOf: service),
+              let mockCharacteristics = mockService.characteristics else {
             return
         }
         
         switch delegate.peripheral(mock,
                                    didReceiveCharacteristicsDiscoveryRequest: characteristicUUIDs,
-                                   for: service) {
+                                   for: mockService) {
         case .success:
             service._characteristics = service._characteristics ?? []
             let initialSize = service._characteristics!.count
             service._characteristics = service._characteristics! +
-                originalCharacteristics
+                mockCharacteristics
                     // Filter all service characteristics that match given list (if set).
                     .filter { characteristicUUIDs?.contains($0.uuid) ?? true }
                     // Filter those of them, that are not already in discovered characteristics.
@@ -1122,31 +1110,21 @@ open class CBMPeripheralMock: CBMPeer, CBMPeripheral {
         guard state == .connected,
               let delegate = mock.connectionDelegate,
               let interval = mock.connectionInterval,
-              let allServices = mock.services else {
-            return
-        }
-        guard let services = services,
-              let parentService = characteristic.optionalService,
-              services.contains(parentService),
-              let originalService = allServices.first(where: {
-                $0.identifier == parentService.identifier
-              }),
-              let originalCharacteristic = originalService.characteristics?.first(where: {
-                  $0.identifier == characteristic.identifier
-              }) else {
-            return
-        }
-        guard let originalDescriptors = originalCharacteristic.descriptors else {
+              let services = services,
+              let parentService = characteristic.optionalService, services.contains(parentService),
+              let mockServices = mock.services,
+              let mockCharacteristic = mockServices.find(mockOf: characteristic),
+              let mockDescriptors = mockCharacteristic.descriptors else {
             return
         }
         
         switch delegate.peripheral(mock,
-                                   didReceiveDescriptorsDiscoveryRequestFor: characteristic) {
+                                   didReceiveDescriptorsDiscoveryRequestFor: mockCharacteristic) {
         case .success:
             characteristic._descriptors = characteristic._descriptors ?? []
             let initialSize = characteristic._descriptors!.count
             characteristic._descriptors = characteristic._descriptors! +
-                originalDescriptors
+                mockDescriptors
                     // Filter those of them, that are not already in discovered descriptors.
                     .filter { d in !characteristic._descriptors!
                         .contains { dd in d.identifier == dd.identifier }
@@ -1182,16 +1160,15 @@ open class CBMPeripheralMock: CBMPeer, CBMPeripheral {
         guard manager.ensurePoweredOn() else { return }
         guard state == .connected,
               let delegate = mock.connectionDelegate,
-              let interval = mock.connectionInterval else {
-            return
-        }
-        guard let services = services,
-              let characteristicService = characteristic.optionalService,
-              services.contains(characteristicService) else {
+              let interval = mock.connectionInterval,
+              let services = services,
+              let service = characteristic.optionalService, services.contains(service),
+              let mockServices = mock.services,
+              let mockCharacteristic = mockServices.find(mockOf: characteristic) else {
             return
         }
         switch delegate.peripheral(mock,
-                                   didReceiveReadRequestFor: characteristic) {
+                                   didReceiveReadRequestFor: mockCharacteristic) {
         case .success(let data):
             queue.asyncAfter(deadline: .now() + interval) { [weak self] in
                 if let self = self, self.state == .connected {
@@ -1217,16 +1194,15 @@ open class CBMPeripheralMock: CBMPeer, CBMPeripheral {
         guard manager.ensurePoweredOn() else { return }
         guard state == .connected,
               let delegate = mock.connectionDelegate,
-              let interval = mock.connectionInterval else {
-            return
-        }
-        guard let services = services,
-              let parentService = descriptor.optionalCharacteristic?.service,
-              services.contains(parentService) else {
+              let interval = mock.connectionInterval,
+              let services = services,
+              let service = descriptor.optionalCharacteristic?.service, services.contains(service),
+              let mockServices = mock.services,
+              let mockDescriptor = mockServices.find(mockOf: descriptor) else {
             return
         }
         switch delegate.peripheral(mock,
-                                   didReceiveReadRequestFor: descriptor) {
+                                   didReceiveReadRequestFor: mockDescriptor) {
         case .success(let data):
             queue.asyncAfter(deadline: .now() + interval) { [weak self] in
                 if let self = self, self.state == .connected {
@@ -1257,18 +1233,17 @@ open class CBMPeripheralMock: CBMPeer, CBMPeripheral {
         guard state == .connected,
               let delegate = mock.connectionDelegate,
               let interval = mock.connectionInterval,
-              let mtu = mock.mtu else {
-            return
-        }
-        guard let services = services,
-              let parentService = characteristic.optionalService,
-              services.contains(parentService) else {
+              let mtu = mock.mtu,
+              let services = services,
+              let service = characteristic.optionalService, services.contains(service),
+              let mockServices = mock.services,
+              let mockCharacteristic = mockServices.find(mockOf: characteristic) else {
             return
         }
         
         if type == .withResponse {
             switch delegate.peripheral(mock,
-                                       didReceiveWriteRequestFor: characteristic,
+                                       didReceiveWriteRequestFor: mockCharacteristic,
                                        data: data) {
             case .success:
                 let packetsCount = max(1, (data.count + mtu - 2) / (mtu - 3))
@@ -1300,7 +1275,7 @@ open class CBMPeripheralMock: CBMPeer, CBMPeripheral {
             }
             
             delegate.peripheral(mock,
-                                didReceiveWriteCommandFor: characteristic,
+                                didReceiveWriteCommandFor: mockCharacteristic,
                                 data: data.subdata(in: 0..<min(mtu - 3, data.count)))
 
             queue.async { [weak self] in
@@ -1323,17 +1298,16 @@ open class CBMPeripheralMock: CBMPeer, CBMPeripheral {
         guard manager.ensurePoweredOn() else { return }
         guard state == .connected,
               let delegate = mock.connectionDelegate,
-              let interval = mock.connectionInterval else {
-            return
-        }
-        guard let services = services,
-              let parentService = descriptor.optionalCharacteristic?.service,
-              services.contains(parentService) else {
+              let interval = mock.connectionInterval,
+              let services = services,
+              let service = descriptor.optionalCharacteristic?.service, services.contains(service),
+              let mockServices = mock.services,
+              let mockDescriptor = mockServices.find(mockOf: descriptor) else {
             return
         }
         
         switch delegate.peripheral(mock,
-                                   didReceiveWriteRequestFor: descriptor,
+                                   didReceiveWriteRequestFor: mockDescriptor,
                                    data: data) {
         case .success:
             queue.asyncAfter(deadline: .now() + interval) { [weak self] in
@@ -1372,12 +1346,11 @@ open class CBMPeripheralMock: CBMPeer, CBMPeripheral {
         guard manager.ensurePoweredOn() else { return }
         guard state == .connected,
               let delegate = mock.connectionDelegate,
-              let interval = mock.connectionInterval else {
-            return
-        }
-        guard let services = services,
-              let parentService = characteristic.optionalService,
-              services.contains(parentService) else {
+              let interval = mock.connectionInterval,
+              let services = services,
+              let service = characteristic.optionalService, services.contains(service),
+              let mockServices = mock.services,
+              let mockCharacteristic = mockServices.find(mockOf: characteristic) else {
             return
         }
         guard enabled != characteristic.isNotifying else {
@@ -1386,7 +1359,7 @@ open class CBMPeripheralMock: CBMPeer, CBMPeripheral {
         
         switch delegate.peripheral(mock,
                                    didReceiveSetNotifyRequest: enabled,
-                                   for: characteristic) {
+                                   for: mockCharacteristic) {
         case .success:
             queue.asyncAfter(deadline: .now() + interval) { [weak self] in
                 if let self = self, self.state == .connected {

--- a/CoreBluetoothMock/Classes/CBMPeripheralSpecDelegate.swift
+++ b/CoreBluetoothMock/Classes/CBMPeripheralSpecDelegate.swift
@@ -75,6 +75,12 @@ public protocol CBMPeripheralSpecDelegate {
     ///            using `peripheral(:didDiscoverIncludedServices:)`.
     func peripheral(_ peripheral: CBMPeripheralSpec,
                     didReceiveIncludedServiceDiscoveryRequest serviceUUIDs: [CBMUUID]?,
+                    for service: CBMServiceMock)
+        -> Result<Void, Error>
+    
+    @available(*, deprecated, message: "Use similar method with CBMServiceMock parameter type.")
+    func peripheral(_ peripheral: CBMPeripheralSpec,
+                    didReceiveIncludedServiceDiscoveryRequest serviceUUIDs: [CBMUUID]?,
                     for service: CBMService)
         -> Result<Void, Error>
 
@@ -89,6 +95,12 @@ public protocol CBMPeripheralSpecDelegate {
     ///            using `peripheral(:didDiscoverCharacteristics:)`.
     func peripheral(_ peripheral: CBMPeripheralSpec,
                     didReceiveCharacteristicsDiscoveryRequest characteristicUUIDs: [CBMUUID]?,
+                    for service: CBMServiceMock)
+        -> Result<Void, Error>
+    
+    @available(*, deprecated, message: "Use similar method with CBMServiceMock parameter type.")
+    func peripheral(_ peripheral: CBMPeripheralSpec,
+                    didReceiveCharacteristicsDiscoveryRequest characteristicUUIDs: [CBMUUID]?,
                     for service: CBMService)
         -> Result<Void, Error>
 
@@ -100,6 +112,11 @@ public protocol CBMPeripheralSpecDelegate {
     ///   - characteristic: The parent characteristic.
     /// - Returns: Success, or a service discovery error. The error will be reported
     ///            using `peripheral(:didDiscoverDescriptors:)`.
+    func peripheral(_ peripheral: CBMPeripheralSpec,
+                    didReceiveDescriptorsDiscoveryRequestFor characteristic: CBMCharacteristicMock)
+        -> Result<Void, Error>
+    
+    @available(*, deprecated, message: "Use similar method with CBMCharacteristicMock parameter type.")
     func peripheral(_ peripheral: CBMPeripheralSpec,
                     didReceiveDescriptorsDiscoveryRequestFor characteristic: CBMCharacteristic)
         -> Result<Void, Error>
@@ -113,6 +130,11 @@ public protocol CBMPeripheralSpecDelegate {
     ///            of a failure, the returned error will be returned to the
     ///            `peripheral(:didUpdateValueFor:error:)`.
     func peripheral(_ peripheral: CBMPeripheralSpec,
+                    didReceiveReadRequestFor characteristic: CBMCharacteristicMock)
+        -> Result<Data, Error>
+    
+    @available(*, deprecated, message: "Use similar method with CBMCharacteristicMock parameter type.")
+    func peripheral(_ peripheral: CBMPeripheralSpec,
                     didReceiveReadRequestFor characteristic: CBMCharacteristic)
         -> Result<Data, Error>
 
@@ -124,6 +146,11 @@ public protocol CBMPeripheralSpecDelegate {
     /// - Returns: When success, the descriptor value should be returned. In case
     ///            of a failure, the returned error will be returned to the
     ///            `peripheral(:didUpdateValueFor:error:)`.
+    func peripheral(_ peripheral: CBMPeripheralSpec,
+                    didReceiveReadRequestFor descriptor: CBMDescriptorMock)
+        -> Result<Data, Error>
+    
+    @available(*, deprecated, message: "Use similar method with CBMDescriptorMock parameter type.")
     func peripheral(_ peripheral: CBMPeripheralSpec,
                     didReceiveReadRequestFor descriptor: CBMDescriptor)
         -> Result<Data, Error>
@@ -137,6 +164,12 @@ public protocol CBMPeripheralSpecDelegate {
     /// - Returns: Success, or the reason of failure. The returned error will be
     ///            returned to the `peripheral(:didWriteValueFor:error:)`.
     func peripheral(_ peripheral: CBMPeripheralSpec,
+                    didReceiveWriteRequestFor characteristic: CBMCharacteristicMock,
+                    data: Data)
+        -> Result<Void, Error>
+    
+    @available(*, deprecated, message: "Use similar method with CBMCharacteristicMock parameter type.")
+    func peripheral(_ peripheral: CBMPeripheralSpec,
                     didReceiveWriteRequestFor characteristic: CBMCharacteristic,
                     data: Data)
         -> Result<Void, Error>
@@ -147,6 +180,11 @@ public protocol CBMPeripheralSpecDelegate {
     ///   - peripheral: The target peripheral specification.
     ///   - characteristic: The target characteristic.
     ///   - data: The data written.
+    func peripheral(_ peripheral: CBMPeripheralSpec,
+                    didReceiveWriteCommandFor characteristic: CBMCharacteristicMock,
+                    data: Data)
+    
+    @available(*, deprecated, message: "Use similar method with CBMCharacteristicMock parameter type.")
     func peripheral(_ peripheral: CBMPeripheralSpec,
                     didReceiveWriteCommandFor characteristic: CBMCharacteristic,
                     data: Data)
@@ -160,6 +198,12 @@ public protocol CBMPeripheralSpecDelegate {
     /// - Returns: Success, or the reason of failure. The returned error will be
     ///            returned to the `peripheral(:didWriteValueFor:error:)`.
     func peripheral(_ peripheral: CBMPeripheralSpec,
+                    didReceiveWriteRequestFor descriptor: CBMDescriptorMock,
+                    data: Data)
+        -> Result<Void, Error>
+    
+    @available(*, deprecated, message: "Use similar method with CBMDescriptorMock parameter type.")
+    func peripheral(_ peripheral: CBMPeripheralSpec,
                     didReceiveWriteRequestFor descriptor: CBMDescriptor,
                     data: Data)
         -> Result<Void, Error>
@@ -171,6 +215,12 @@ public protocol CBMPeripheralSpecDelegate {
     ///   - enabled: Whether notifications or indications were enabled or disabled.
     ///   - characteristic: The target characteristic.
     /// - Returns: Success, or the reason of a failure.
+    func peripheral(_ peripheral: CBMPeripheralSpec,
+                    didReceiveSetNotifyRequest enabled: Bool,
+                    for characteristic: CBMCharacteristicMock)
+        -> Result<Void, Error>
+    
+    @available(*, deprecated, message: "Use similar method with CBMCharacteristicMock parameter type.")
     func peripheral(_ peripheral: CBMPeripheralSpec,
                     didReceiveSetNotifyRequest enabled: Bool,
                     for characteristic: CBMCharacteristic)
@@ -204,50 +254,102 @@ public extension CBMPeripheralSpecDelegate {
         -> Result<Void, Error> {
             return .success(())
     }
-        
+    
+    func peripheral(_ p: CBMPeripheralSpec,
+                    didReceiveIncludedServiceDiscoveryRequest serviceUUIDs: [CBMUUID]?,
+                    for service: CBMServiceMock)
+        -> Result<Void, Error> {
+            return peripheral(p, didReceiveIncludedServiceDiscoveryRequest: serviceUUIDs, for: service as CBMService)
+    }
+    
     func peripheral(_ peripheral: CBMPeripheralSpec,
                     didReceiveCharacteristicsDiscoveryRequest characteristicUUIDs: [CBMUUID]?,
                     for service: CBMService)
         -> Result<Void, Error> {
             return .success(())
-   }
-            
+    }
+    
+    func peripheral(_ p: CBMPeripheralSpec,
+                    didReceiveCharacteristicsDiscoveryRequest characteristicUUIDs: [CBMUUID]?,
+                    for service: CBMServiceMock)
+        -> Result<Void, Error> {
+            return peripheral(p, didReceiveCharacteristicsDiscoveryRequest: characteristicUUIDs, for: service as CBMService)
+    }
+    
     func peripheral(_ peripheral: CBMPeripheralSpec,
                     didReceiveDescriptorsDiscoveryRequestFor characteristic: CBMCharacteristic)
         -> Result<Void, Error> {
             return .success(())
-   }
+    }
+    
+    func peripheral(_ p: CBMPeripheralSpec,
+                    didReceiveDescriptorsDiscoveryRequestFor characteristic: CBMCharacteristicMock)
+        -> Result<Void, Error> {
+            return peripheral(p, didReceiveDescriptorsDiscoveryRequestFor: characteristic as CBMCharacteristic)
+    }
     
     func peripheral(_ peripheral: CBMPeripheralSpec,
                     didReceiveReadRequestFor characteristic: CBMCharacteristic)
         -> Result<Data, Error> {
             return .failure(CBMATTError(.readNotPermitted))
-   }
-        
+    }
+    
+    func peripheral(_ p: CBMPeripheralSpec,
+                    didReceiveReadRequestFor characteristic: CBMCharacteristicMock)
+        -> Result<Data, Error> {
+            return peripheral(p, didReceiveReadRequestFor: characteristic as CBMCharacteristic)
+    }
+    
     func peripheral(_ peripheral: CBMPeripheralSpec,
                     didReceiveReadRequestFor descriptor: CBMDescriptor)
         -> Result<Data, Error> {
             return .failure(CBMATTError(.readNotPermitted))
     }
-
+    
+    func peripheral(_ p: CBMPeripheralSpec,
+                    didReceiveReadRequestFor descriptor: CBMDescriptorMock)
+        -> Result<Data, Error> {
+            return peripheral(p, didReceiveReadRequestFor: descriptor as CBMDescriptor)
+    }
+    
     func peripheral(_ peripheral: CBMPeripheralSpec,
                     didReceiveWriteRequestFor characteristic: CBMCharacteristic,
                     data: Data)
         -> Result<Void, Error> {
             return .failure(CBMATTError(.writeNotPermitted))
     }
-
+    
+    func peripheral(_ p: CBMPeripheralSpec,
+                    didReceiveWriteRequestFor characteristic: CBMCharacteristicMock,
+                    data: Data)
+        -> Result<Void, Error> {
+            return peripheral(p, didReceiveWriteRequestFor: characteristic as CBMCharacteristic, data: data)
+    }
+    
     func peripheral(_ peripheral: CBMPeripheralSpec,
                     didReceiveWriteCommandFor characteristic: CBMCharacteristic,
                     data: Data) {
         // Empty default implementation
     }
-
+    
+    func peripheral(_ p: CBMPeripheralSpec,
+                    didReceiveWriteCommandFor characteristic: CBMCharacteristicMock,
+                    data: Data) {
+        peripheral(p, didReceiveWriteCommandFor: characteristic as CBMCharacteristic, data: data)
+    }
+    
     func peripheral(_ peripheral: CBMPeripheralSpec,
                     didReceiveWriteRequestFor descriptor: CBMDescriptor,
                     data: Data)
         -> Result<Void, Error> {
             return .failure(CBATTError(.writeNotPermitted))
+    }
+    
+    func peripheral(_ p: CBMPeripheralSpec,
+                    didReceiveWriteRequestFor descriptor: CBMDescriptorMock,
+                    data: Data)
+        -> Result<Void, Error> {
+            return peripheral(p, didReceiveWriteRequestFor: descriptor as CBMDescriptor, data: data)
     }
     
     func peripheral(_ peripheral: CBMPeripheralSpec,
@@ -264,5 +366,12 @@ public extension CBMPeripheralSpecDelegate {
             } else {
                 return .failure(CBMError(.invalidHandle))
             }
+    }
+    
+    func peripheral(_ p: CBMPeripheralSpec,
+                    didReceiveSetNotifyRequest enabled: Bool,
+                    for characteristic: CBMCharacteristicMock)
+        -> Result<Void, Error> {
+            return peripheral(p, didReceiveSetNotifyRequest: enabled, for: characteristic as CBMCharacteristic)
     }
 }

--- a/Example/Tests/MultipleInstancesTest.swift
+++ b/Example/Tests/MultipleInstancesTest.swift
@@ -1,0 +1,181 @@
+/*
+* Copyright (c) 2020, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+
+import XCTest
+@testable import nRF_Blinky
+@testable import CoreBluetoothMock
+
+class MultipleInstancesTest: XCTestCase {
+
+    override func setUpWithError() throws {
+        // This method is called AFTER ScannerTableViewController.viewDidLoad()
+        // where the BlinkyManager is instantiated. A separate mock manager
+        // is not created in this test.
+        // Initially mock Bluetooth adapter is powered Off.
+        CBMCentralManagerMock.simulatePeripherals([powerPack])
+        CBMCentralManagerMock.simulateInitialState(.poweredOn)
+    }
+
+    override func tearDownWithError() throws {
+        // We can't call CBMCentralManagerMock.tearDownSimulation() here.
+        // That would invalidate the BlinkyManager in ScannerTableViewController.
+        // The central manager must be reused, so let's just power mock off,
+        // which will allow us to set different set of peripherals in another test.
+        CBMCentralManagerMock.simulatePowerOff()
+    }
+
+    func testMultipleServiceInstances() throws {
+        // Devices might have been scanned and cached by some other test.
+        // Make sure they're treated as new devices by changing their addresses.
+        powerPack.simulateProximityChange(.immediate)
+        
+        let managerPoweredOn = XCTestExpectation(description: "Powered On")
+        let powerPackFound = XCTestExpectation(description: "Found")
+        let otherFound = XCTestExpectation(description: "Other found")
+        otherFound.isInverted = true
+        let twoBatteryServicesFound = XCTestExpectation(description: "Battery Services found")
+        let primaryBatteryLevelCorrect = XCTestExpectation(description: "Primary Battery at 75%")
+        let secondaryBatteryLevelCorrect = XCTestExpectation(description: "Secondary Battery at 100%")
+        
+        // Create an instance of a mock CBMCentralManager.
+        let manager = CBMCentralManagerMock()
+        
+        // Define the CBMPeripheralDelegate, which will wait until the serivces are
+        // discovered and will discover characteristics.
+        let peripheralDelegate = CBMPeripheralDelegateProxy()
+        peripheralDelegate.didDiscoverServices = { peripheral, error in
+            XCTAssertNil(error)
+            
+            powerPackFound.fulfill()
+            
+            if let services = peripheral.services, services.count == 2 {
+                twoBatteryServicesFound.fulfill()
+                
+                services.forEach { batteryService in
+                    peripheral.discoverCharacteristics([.batteryLevelCharacteristic], for: batteryService)
+                }
+            }
+        }
+        peripheralDelegate.didDiscoverCharacteristics = { peripheral, service, error in
+            XCTAssertNil(error)
+            
+            XCTAssertNotNil(service.characteristics)
+            XCTAssert(service.characteristics?.count == 1)
+            
+            if let batteryLevel = service.characteristics?.first {
+                peripheral.discoverDescriptors(for: batteryLevel)
+            }
+        }
+        peripheralDelegate.didDiscoverDescriptors = { peripheral, characteristic, error in
+            XCTAssertNil(error)
+            
+            XCTAssertNotNil(characteristic.descriptors)
+            XCTAssert(characteristic.descriptors?.count == 1)
+            
+            if let userDescription = characteristic.descriptors?.first {
+                peripheral.readValue(for: userDescription)
+            }
+        }
+        peripheralDelegate.didUpdateDescriptorValue = { peripheral, descriptor, error in
+            XCTAssertNil(error)
+            
+            if let parent = descriptor.optionalCharacteristic {
+                peripheral.readValue(for: parent)
+            }
+        }
+        peripheralDelegate.didUpdateCharacteristicValue = { peripheral, characteristic, error in
+            XCTAssertNil(error)
+            
+            if let userDescription = characteristic.descriptors?.first,
+               let value = userDescription.value as? Data,
+               let description = String(data: value, encoding: .utf8) {
+                switch description {
+                case "Primary":
+                    XCTAssertNotNil(characteristic.value)
+                    XCTAssert(characteristic.value?.count == 1)
+                    XCTAssert(characteristic.value?[0] == 75)
+                    
+                    if characteristic.value?[0] == 75 {
+                        primaryBatteryLevelCorrect.fulfill()
+                    }
+                case "Secondary":
+                    XCTAssertNotNil(characteristic.value)
+                    XCTAssert(characteristic.value?.count == 1)
+                    XCTAssert(characteristic.value?[0] == 100)
+                    
+                    if characteristic.value?[0] == 100 {
+                        secondaryBatteryLevelCorrect.fulfill()
+                    }
+                default:
+                    XCTFail()
+                }
+            } else {
+                XCTFail("Characteristic User Description Descriptor not found")
+            }
+        }
+        
+        // Define the CBCentralManagerDelegate, which will wait until the manager is ready
+        // and will check the successful retrieval.
+        let delegate = CBMCentralManagerDelegateProxy()
+        delegate.didUpdateState = { _ in managerPoweredOn.fulfill() }
+        delegate.didDiscoverPeripheral = { manager, peripheral, _, _ in
+            guard peripheral.identifier == powerPack.identifier else {
+                otherFound.fulfill()
+                return
+            }
+            powerPackFound.fulfill()
+            
+            // Connect to the device when found.
+            peripheral.delegate = peripheralDelegate
+            manager.connect(peripheral)
+        }
+        delegate.didConnect = { manager, peripheral in
+            // Discover services.
+            peripheral.discoverServices([.batteryService])
+        }
+        manager.delegate = delegate
+        
+        // Wait until the manager is initialized.
+        wait(for: [managerPoweredOn], timeout: 1.0)
+        
+        // Scan only for HRM device. Other devices may also be in range.
+        manager.scanForPeripherals(withServices: [.batteryService])
+        
+        wait(for: [
+                powerPackFound, otherFound,
+                twoBatteryServicesFound,
+                primaryBatteryLevelCorrect,
+                secondaryBatteryLevelCorrect
+             ],
+             timeout: 3.0)
+    }
+
+}

--- a/Example/Tests/RetrievingDevicesTest.swift
+++ b/Example/Tests/RetrievingDevicesTest.swift
@@ -212,7 +212,11 @@ class RetrievingDevicesTest: XCTestCase {
         // Scan only for HRM device. Other devices may also be in range.
         manager.scanForPeripherals(withServices: [hrmServiceUUID])
         
-        wait(for: [hrmFound, otherFound, hrmNotRetrieved, hrmStillNotRetrieved, hrmRetrieved], timeout: 1.0)
+        wait(for: [
+                hrmFound, otherFound,
+                hrmNotRetrieved, hrmStillNotRetrieved, hrmRetrieved
+             ],
+             timeout: 4.0)
     }
 
 }

--- a/Example/nRFBlinky.xcodeproj/project.pbxproj
+++ b/Example/nRFBlinky.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		2DBB2F44478EB7F4C0DF3AA4 /* BlinkyManagerEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DBB27ABD18F3DAECC075CF2 /* BlinkyManagerEvents.swift */; };
 		526EA53D240D2F8100BF70B2 /* UITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526EA53C240D2F8100BF70B2 /* UITests.swift */; };
 		52991CE726C26CE90029CD9E /* RetrievingDevicesTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52991CE626C26CE90029CD9E /* RetrievingDevicesTest.swift */; };
+		52A128B726CD9AF800DE5F37 /* MultipleInstancesTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A128B626CD9AF800DE5F37 /* MultipleInstancesTest.swift */; };
 		52A648F1240E83F000817F2F /* NormalBehaviorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A648F0240E83F000817F2F /* NormalBehaviorTest.swift */; };
 		52A648F9240E95F700817F2F /* MockPeripherals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52B537D723FC129400372948 /* MockPeripherals.swift */; };
 		52A648FB24125D1D00817F2F /* CoreBluetoothTypeAliases.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52A648FA24125D1D00817F2F /* CoreBluetoothTypeAliases.swift */; };
@@ -64,6 +65,7 @@
 		526EA53C240D2F8100BF70B2 /* UITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITests.swift; sourceTree = "<group>"; };
 		526EA53E240D2F8100BF70B2 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		52991CE626C26CE90029CD9E /* RetrievingDevicesTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetrievingDevicesTest.swift; sourceTree = "<group>"; };
+		52A128B626CD9AF800DE5F37 /* MultipleInstancesTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipleInstancesTest.swift; sourceTree = "<group>"; };
 		52A648E0240E7BDF00817F2F /* CoreBluetoothMock.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = CoreBluetoothMock.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		52A648EE240E83F000817F2F /* nRFBlinky_Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = nRFBlinky_Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		52A648F0240E83F000817F2F /* NormalBehaviorTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NormalBehaviorTest.swift; sourceTree = "<group>"; };
@@ -183,6 +185,7 @@
 				2DBB22CFA82E35CBA3BB326F /* ResetTest.swift */,
 				52E905CD24DD35A100BB5740 /* FailedConnectionTest.swift */,
 				52991CE626C26CE90029CD9E /* RetrievingDevicesTest.swift */,
+				52A128B626CD9AF800DE5F37 /* MultipleInstancesTest.swift */,
 				2DBB2F5ACA6DCE530B0DDE90 /* EventHelper.swift */,
 				52A648F8240E844700817F2F /* Supporting Files */,
 			);
@@ -615,6 +618,7 @@
 				52991CE726C26CE90029CD9E /* RetrievingDevicesTest.swift in Sources */,
 				2DBB258568F7E07E0DFA3B4E /* EventHelper.swift in Sources */,
 				52E905CE24DD35A100BB5740 /* FailedConnectionTest.swift in Sources */,
+				52A128B726CD9AF800DE5F37 /* MultipleInstancesTest.swift in Sources */,
 				2DBB2D9D87AA009D95C10DEE /* ResetTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/nRFBlinky/MockPeripherals.swift
+++ b/Example/nRFBlinky/MockPeripherals.swift
@@ -235,12 +235,12 @@ extension CBMServiceMock {
     
 }
 
-public class PowerPackCBMPeripheralSpecDelegate: CBMPeripheralSpecDelegate {
+private class PowerPackCBMPeripheralSpecDelegate: CBMPeripheralSpecDelegate {
     private let primaryBatteryLevel: UInt8 = 75
     private let secondaryBatteryLevel: UInt8 = 100
     
-    public func peripheral(_ peripheral: CBMPeripheralSpec,
-                           didReceiveReadRequestFor characteristic: CBMCharacteristicMock)
+    func peripheral(_ peripheral: CBMPeripheralSpec,
+                    didReceiveReadRequestFor characteristic: CBMCharacteristicMock)
             -> Result<Data, Error> {
         if characteristic == CBMCharacteristicMock.primaryBatteryLevelCharacteristic {
             return .success(Data([primaryBatteryLevel]))
@@ -251,8 +251,8 @@ public class PowerPackCBMPeripheralSpecDelegate: CBMPeripheralSpecDelegate {
         return .failure(CBMATTError(.invalidHandle))
     }
     
-    public func peripheral(_ peripheral: CBMPeripheralSpec,
-                           didReceiveReadRequestFor descriptor: CBMDescriptorMock)
+    func peripheral(_ peripheral: CBMPeripheralSpec,
+                    didReceiveReadRequestFor descriptor: CBMDescriptorMock)
             -> Result<Data, Error> {
         if descriptor.characteristic == CBMCharacteristicMock.primaryBatteryLevelCharacteristic {
             return .success("Primary".data(using: .utf8)!)

--- a/Example/nRFBlinky/MockPeripherals.swift
+++ b/Example/nRFBlinky/MockPeripherals.swift
@@ -83,7 +83,7 @@ private class BlinkyCBMPeripheralSpecDelegate: CBMPeripheralSpecDelegate {
     }
 
     func peripheral(_ peripheral: CBMPeripheralSpec,
-                    didReceiveReadRequestFor characteristic: CBMCharacteristic)
+                    didReceiveReadRequestFor characteristic: CBMCharacteristicMock)
             -> Result<Data, Error> {
         if characteristic.uuid == .ledCharacteristic {
             return .success(ledData)
@@ -93,7 +93,7 @@ private class BlinkyCBMPeripheralSpecDelegate: CBMPeripheralSpecDelegate {
     }
     
     func peripheral(_ peripheral: CBMPeripheralSpec,
-                    didReceiveWriteRequestFor characteristic: CBMCharacteristic,
+                    didReceiveWriteRequestFor characteristic: CBMCharacteristicMock,
                     data: Data) -> Result<Void, Error> {
         if data.count > 0 {
             ledEnabled = data[0] != 0x00
@@ -176,7 +176,7 @@ let thingy = CBMPeripheralSpec
     .advertising(
         advertisementData: [
             CBMAdvertisementDataServiceUUIDsKey : [
-                CBUUID(string: "FEAA")  // Eddystone
+                CBMUUID(string: "FEAA")  // Eddystone
             ],
             CBMAdvertisementDataServiceDataKey : [
                 // Physical Web beacon: 10ee03676f2e676c2f7049576466972
@@ -187,4 +187,99 @@ let thingy = CBMPeripheralSpec
             ]
         ],
         withInterval: 0.100)
+    .build()
+
+// MARK: - A device with 2 batteries
+
+extension CBMUUID {
+    static let batteryService             = CBMUUID(string: "180F")
+    static let batteryLevelCharacteristic = CBMUUID(string: "2A19")
+    static let characteristicUserDesr     = CBMUUID(string: "2901")
+}
+
+// The mocked Power Pack device has 2 batteries: primary and secondary.
+// Battery Service specification allows only one Battery Level
+// characteristic in each service, therefore below we define
+// two Battery Services, one for each battery.
+//
+// The service instance cannot be reused, as each has its own unique
+// identifier, that is used to distinguish them.
+
+extension CBMCharacteristicMock {
+    
+    static let primaryBatteryLevelCharacteristic = CBMCharacteristicMock(
+        type: .batteryLevelCharacteristic,
+        properties: [.notify, .read],
+        descriptors: CBMDescriptorMock(type: .characteristicUserDesr)
+    )
+    
+    static let secondaryBatteryLevelCharacteristic = CBMCharacteristicMock(
+        type: .batteryLevelCharacteristic,
+        properties: [.notify, .read],
+        descriptors: CBMDescriptorMock(type: .characteristicUserDesr)
+    )
+    
+}
+
+extension CBMServiceMock {
+
+    static let primaryBatteryService = CBMServiceMock(
+        type: .batteryService, primary: true,
+        characteristics: .primaryBatteryLevelCharacteristic
+    )
+    
+    static let secondaryBatteryService = CBMServiceMock(
+        type: .batteryService, primary: true,
+        characteristics: .secondaryBatteryLevelCharacteristic
+    )
+    
+}
+
+public class PowerPackCBMPeripheralSpecDelegate: CBMPeripheralSpecDelegate {
+    private let primaryBatteryLevel: UInt8 = 75
+    private let secondaryBatteryLevel: UInt8 = 100
+    
+    public func peripheral(_ peripheral: CBMPeripheralSpec,
+                           didReceiveReadRequestFor characteristic: CBMCharacteristicMock)
+            -> Result<Data, Error> {
+        if characteristic == CBMCharacteristicMock.primaryBatteryLevelCharacteristic {
+            return .success(Data([primaryBatteryLevel]))
+        }
+        if characteristic == CBMCharacteristicMock.secondaryBatteryLevelCharacteristic {
+            return .success(Data([secondaryBatteryLevel]))
+        }
+        return .failure(CBMATTError(.invalidHandle))
+    }
+    
+    public func peripheral(_ peripheral: CBMPeripheralSpec,
+                           didReceiveReadRequestFor descriptor: CBMDescriptorMock)
+            -> Result<Data, Error> {
+        if descriptor.characteristic == CBMCharacteristicMock.primaryBatteryLevelCharacteristic {
+            return .success("Primary".data(using: .utf8)!)
+        }
+        if descriptor.characteristic == CBMCharacteristicMock.secondaryBatteryLevelCharacteristic {
+            return .success("Secondary".data(using: .utf8)!)
+        }
+        return .failure(CBMATTError(.invalidHandle))
+    }
+}
+
+let powerPack = CBMPeripheralSpec
+    .simulatePeripheral(proximity: .outOfRange)
+    .advertising(
+        advertisementData: [
+            CBMAdvertisementDataLocalNameKey    : "Power Pack",
+            CBMAdvertisementDataServiceUUIDsKey : [CBMUUID.batteryService],
+            CBMAdvertisementDataIsConnectable   : true as NSNumber
+        ],
+        withInterval: 0.250)
+    .connectable(
+        name: "Power Pack",
+        services: [
+            .primaryBatteryService,
+            .secondaryBatteryService,
+        ],
+        delegate: PowerPackCBMPeripheralSpecDelegate(),
+        connectionInterval: 0.045,
+        mtu: 186)
     .build()

--- a/Example/nRFBlinky/MockPeripherals.swift
+++ b/Example/nRFBlinky/MockPeripherals.swift
@@ -236,17 +236,25 @@ extension CBMServiceMock {
 }
 
 private class PowerPackCBMPeripheralSpecDelegate: CBMPeripheralSpecDelegate {
-    private let primaryBatteryLevel: UInt8 = 75
-    private let secondaryBatteryLevel: UInt8 = 100
+    private var primaryBatteryLevel: UInt8 = 75
+    private var secondaryBatteryLevel: UInt8 = 100
+    
+    private var primaryBatteryLevelData: Data {
+        return Data([primaryBatteryLevel])
+    }
+    
+    private var secondaryBatteryLevelData: Data {
+        return Data([secondaryBatteryLevel])
+    }
     
     func peripheral(_ peripheral: CBMPeripheralSpec,
                     didReceiveReadRequestFor characteristic: CBMCharacteristicMock)
             -> Result<Data, Error> {
         if characteristic == CBMCharacteristicMock.primaryBatteryLevelCharacteristic {
-            return .success(Data([primaryBatteryLevel]))
+            return .success(primaryBatteryLevelData)
         }
         if characteristic == CBMCharacteristicMock.secondaryBatteryLevelCharacteristic {
-            return .success(Data([secondaryBatteryLevel]))
+            return .success(secondaryBatteryLevelData)
         }
         return .failure(CBMATTError(.invalidHandle))
     }


### PR DESCRIPTION
This PR fixes #42. It contains some breaking changes.

Changes:
- Callback methods in `CBMPeripheralSpecDelegate` with parameters of type `CBMService`, `CBMCharacteristic` or `CBMDescriptor` have been replaced with new ones with parameter of types `CBMServiceMock`, `CBMCharacteristicMock` and `CBMDescriptorMock`. The old methods will still be called, but user's code should be migrated to the new methods, as this may change in the future.
- The attribute passed to those methods are the original attributes specified in peripheral spec. Before, the per-client not-mock copies were passed. It is now possible to distinguish instances by comparing them to the definitions. See example below:
   https://github.com/NordicSemiconductor/IOS-CoreBluetooth-Mock/blob/fa98b547f245a50eb6d9e3e20417bf35f6cf342d/Example/nRFBlinky/MockPeripherals.swift#L208-L236
   https://github.com/NordicSemiconductor/IOS-CoreBluetooth-Mock/blob/fa98b547f245a50eb6d9e3e20417bf35f6cf342d/Example/nRFBlinky/MockPeripherals.swift#L250-L260
- The new say to set `includedServices` in `CBMServiceMock` is using the initiator. The setters for `includedServices` and `characteristics` were removed, as they should not be changed in service lifetime.
- Two `contains` methods were removed from `CBMServiceMock` and `CBMCharacteristicMock`. They were not used internally, but as they were `open` it may affect user's implementation.