### PR TITLE
Allow initializing a CBMServiceMock with arrays of services and characteristics

### DIFF
--- a/CoreBluetoothMock/Classes/CBMAttributes.swift
+++ b/CoreBluetoothMock/Classes/CBMAttributes.swift
@@ -125,14 +125,29 @@ open class CBMServiceMock: CBMService {
     ///   - isPrimary: The type of the service (primary or secondary).
     ///   - includedServices: Optional list of included services.
     ///   - characteristics: Optional list of characteristics.
-    public init(type uuid: CBMUUID, primary isPrimary: Bool,
+    public convenience init(type uuid: CBMUUID, primary isPrimary: Bool,
                 includedService: CBMServiceMock...,
                 characteristics: CBMCharacteristicMock...) {
+        self.init(type: uuid,
+                  primary: isPrimary,
+                  includedService: includedService,
+                  characteristics: characteristics)
+    }
+
+    /// Returns a service, initialized with a service type and UUID.
+    /// - Parameters:
+    ///   - uuid: The Bluetooth UUID of the service.
+    ///   - isPrimary: The type of the service (primary or secondary).
+    ///   - includedServices: Optional array of included services.
+    ///   - characteristics: Optional aray of characteristics.
+    public init(type uuid: CBMUUID, primary isPrimary: Bool,
+                includedService: [CBMServiceMock],
+                characteristics: [CBMCharacteristicMock]) {
         super.init(type: uuid, primary: isPrimary)
         self._includedServices = includedService
         self._characteristics = characteristics
     }
-    
+
     open override func isEqual(_ object: Any?) -> Bool {
         if let other = object as? CBMServiceMock {
             return identifier == other.identifier

--- a/CoreBluetoothMock/Classes/CBMAttributes.swift
+++ b/CoreBluetoothMock/Classes/CBMAttributes.swift
@@ -141,11 +141,15 @@ open class CBMServiceMock: CBMService {
     ///   - includedServices: Optional array of included services.
     ///   - characteristics: Optional aray of characteristics.
     public init(type uuid: CBMUUID, primary isPrimary: Bool,
-                includedService: [CBMServiceMock],
-                characteristics: [CBMCharacteristicMock]) {
+                includedService: [CBMServiceMock]? = nil,
+                characteristics: [CBMCharacteristicMock]? = nil) {
         super.init(type: uuid, primary: isPrimary)
-        self._includedServices = includedService
-        self._characteristics = characteristics
+        if let includedService = includedService {
+            self._includedServices = includedService
+        }
+        if let characteristics = characteristics {
+            self._characteristics = characteristics
+        }
     }
 
     open override func isEqual(_ object: Any?) -> Bool {


### PR DESCRIPTION
This is a small patch to add another `init` method to CBMServiceMock.  The existing method takes variadic parameters.  Unfortunately, as far as I can tell, Swift doesn't provide a way to pass an array to a method that takes variadic params.  The new init method takes arrays instead so between the two, now you can use variadic params or pass an array. 

The existing init now calls the new init, so it should be getting exercised in all the unit tests.
