### PR TITLE
Make sure to get the latest object from CB on retrievePeripherals

### DIFF
--- a/CoreBluetoothMock/Classes/CBMCentralManagerNative.swift
+++ b/CoreBluetoothMock/Classes/CBMCentralManagerNative.swift
@@ -212,7 +212,6 @@ public class CBMCentralManagerNative: CBMCentralManager {
     public override func retrievePeripherals(withIdentifiers identifiers: [UUID]) -> [CBMPeripheral] {
         let retrievedPeripherals = manager.retrievePeripherals(withIdentifiers: identifiers)
         retrievedPeripherals
-            .filter { peripherals[$0.identifier] == nil }
             .forEach { peripherals[$0.identifier] = CBMPeripheralNative($0) }
         return peripherals
             .filter { identifiers.contains($0.key) }
@@ -223,7 +222,6 @@ public class CBMCentralManagerNative: CBMCentralManager {
     public override func retrieveConnectedPeripherals(withServices serviceUUIDs: [CBMUUID]) -> [CBMPeripheral] {
         let retrievedPeripherals = manager.retrieveConnectedPeripherals(withServices: serviceUUIDs)
         retrievedPeripherals
-            .filter { peripherals[$0.identifier] == nil }
             .forEach { peripherals[$0.identifier] = CBMPeripheralNative($0) }
         return peripherals
             .filter { entry in retrievedPeripherals.contains(where: { $0.identifier == entry.key }) }


### PR DESCRIPTION
Normally, you can keep a cache of CBPeripheral objects and use them for operations. There seems to be an edge case where this isn't true: bluetoothd crashes. When bluetoothd crashes, CoreBluetooth seems to recreate all the objects and only accept operations from the new ones. Attempting to use an old object will just silently fail and print out an API MISUSE message to the console. The way to get around this is by always retrieving a new CBPeripheral after the central goes into a `resetting` state and back into `poweredOn`. 

I don't have a way of reliably crashing bluetoothd, so this case is pretty much impossible to test. The only way to really tell the objects apart is by checking the pointer address. 