### PR TITLE
allow advertising data to be dynamically changed

### DIFF
--- a/CoreBluetoothMock/Classes/CBMPeripheralSpec.swift
+++ b/CoreBluetoothMock/Classes/CBMPeripheralSpec.swift
@@ -76,7 +76,7 @@ public class CBMPeripheralSpec {
     /// The device's advertising data.
     /// Make sure to include `CBAdvertisementDataIsConnectable` if
     /// the device is connectable.
-    public let advertisementData: [String : Any]?
+    public var advertisementData: [String : Any]?
     /// The advertising interval.
     public let advertisingInterval: TimeInterval?
     


### PR DESCRIPTION
Many peripherals use advertising broadcast data with the `CBMAdvertisementDataManufacturerDataKey` key. This modifications allows to dynamically set new advertising data via e.g. a `Timer()`

Here is some excerpts form my code with dynamic advertising

```swift
private class MockDeviceCBMPeripheralSpecDelegate: CBMPeripheralSpecDelegate {
...
    var timer: Timer!
    
    init() {
      setup()
    }
    
    func setup() {
      timer = { Timer.scheduledTimer(timeInterval: 2.0, target: self, selector: #selector(simulateDevice), userInfo: nil, repeats: true) }()
    }
    
    func reset() {
      setup()
    }
...
```

  ```swift
@objc
func simulateDevice() {
    let mnf = [CBMAdvertisementDataManufacturerDataKey : [
      u,
      iSolar,
      UInt32(_solCharge_Ah * 1_000),
      Int32(_solEnergy_Wh * 1_000),
      Int16(iBatt/8),
      UInt8(battSoc/10)].data()
    ] as [String : Any]
    let adv = advertising.merging(mnf) { (_,new) in new }
    mockDevice.advertisementData = adv
  }
```

```swift
let advertising: [String: Any] = [
  CBMAdvertisementDataLocalNameKey    : "Mock Device",
  CBMAdvertisementDataServiceUUIDsKey : [CBMUUID.mockService],
  CBMAdvertisementDataIsConnectable   : true as NSNumber,
  CBMAdvertisementDataManufacturerDataKey: Data([0,0,0,0,0,0,0,0,0,0,0,0,0,0,66])
]

let mockDevice = CBMPeripheralSpec
  .simulatePeripheral(proximity: .immediate)
    .advertising(
        advertisementData: advertising,
        withInterval: 0.250,
        alsoWhenConnected: true)
    .connectable(
        name: "Mock Device",
        services: [.devInfoService, .commsService, .mockService],
        delegate: MockDeviceCBMPeripheralSpecDelegate(),
        connectionInterval: 0.150,
        mtu: 251)
    .build()

```