### PR TITLE
Fix typos in codebase

### DIFF
--- a/CoreBluetoothMock/Classes/CBMAttributes.swift
+++ b/CoreBluetoothMock/Classes/CBMAttributes.swift
@@ -76,7 +76,7 @@ open class CBMService: CBMAttribute {
     ///   - isPrimary: The type of the service (primary or secondary).
     init(type uuid: CBMUUID, primary isPrimary: Bool) {
         self.identifier = UUID()
-        self.peripheral = uninitializedPeriperheral
+        self.peripheral = uninitializedPeripheral
         self._uuid = uuid
         self.isPrimary = isPrimary
     }
@@ -395,7 +395,7 @@ internal extension Array where Element == CBMServiceMock {
 
 // MARK: - Mocking uninitialized objects
 
-fileprivate let uninitializedPeriperheral   = CBMPeripheralUninitialized()
+fileprivate let uninitializedPeripheral   = CBMPeripheralUninitialized()
 fileprivate let uninitializedService        = CBMServiceUninitialized()
 fileprivate let uninitializedCharacteristic = CBMCharacteristicUninitialized()
 

--- a/CoreBluetoothMock/Classes/CBMCentralManager.swift
+++ b/CoreBluetoothMock/Classes/CBMCentralManager.swift
@@ -33,14 +33,14 @@ import CoreBluetooth
 open class CBMCentralManager: NSObject {
     
     /// A dummy initializer that allows overriding `CBMCentralManager` class and also
-    /// gives a warninig when trying to migrate from native `CBCentralManager`
+    /// gives a warning when trying to migrate from native `CBCentralManager`
     /// to `CBMCentralManager`. This method does nothing.
     ///
     /// If you need to create your own implementation of central manager, call it. See also
     /// [Issue #55](https://github.com/NordicSemiconductor/IOS-CoreBluetooth-Mock/issues/55).
     ///
     /// If you migrated to CoreBluetooth Mock and are getting an error with
-    /// instantiating a `CBMCentralBanager` instance, use
+    /// instantiating a `CBMCentralManager` instance, use
     /// `CBMCentalManagerFactory.instance(...)` instead.
     ///
     /// See [documentation](https://github.com/NordicSemiconductor/IOS-CoreBluetooth-Mock/#other-required-changes).
@@ -202,7 +202,7 @@ open class CBMCentralManager: NSObject {
     
     /// Cancels an active or pending local connection to a peripheral.
     ///
-    /// This method is nonblocking, and any `CBMPeripheral` class commands
+    /// This method is non-blocking, and any `CBMPeripheral` class commands
     /// that are still pending to peripheral may not complete. Because
     /// other apps may still have a connection to the peripheral, canceling
     /// a local connection doesn’t guarantee that the underlying physical

--- a/CoreBluetoothMock/Classes/CBMCentralManagerMock.swift
+++ b/CoreBluetoothMock/Classes/CBMCentralManagerMock.swift
@@ -237,7 +237,7 @@ open class CBMCentralManagerMock: CBMCentralManager {
     ///
     /// This method may only be called before any central manager was created
     /// or when Bluetooth state is `.poweredOff`. Existing list of peripherals
-    /// will be overritten.
+    /// will be overridden.
     /// - Parameter peripherals: Peripherals specifications.
     public static func simulatePeripherals(_ peripherals: [CBMPeripheralSpec]) {
         guard managers.isEmpty || managerState == .poweredOff else {
@@ -473,8 +473,8 @@ open class CBMCentralManagerMock: CBMCentralManager {
     @available(iOS 13.1, macOS 10.15, tvOS 13.1, watchOS 6.1, *)
     open override class var authorization: CBMManagerAuthorization {
         if let rawValue = CBMCentralManagerMock.bluetoothAuthorization,
-           let authotization = CBMManagerAuthorization(rawValue: rawValue) {
-            return authotization
+           let authorization = CBMManagerAuthorization(rawValue: rawValue) {
+            return authorization
         } else {
             // If `simulateAuthorization(:)` was not called, .allowedAlways is assumed.
             return .allowedAlways

--- a/CoreBluetoothMock/Classes/CBMPeripheralSpec.swift
+++ b/CoreBluetoothMock/Classes/CBMPeripheralSpec.swift
@@ -242,7 +242,7 @@ public class CBMPeripheralSpec {
         isKnown = true
     }
     
-    /// Simulates a change of the devuice's MAC address.
+    /// Simulates a change of the device's MAC address.
     ///
     /// MAC addresses are not available through iOS API. Each MAC gets
     /// assigned a UUID by which the device can be identified and retrieved

--- a/Example/Tests/FailedConnectionTest.swift
+++ b/Example/Tests/FailedConnectionTest.swift
@@ -102,5 +102,4 @@ class FailedConnectionTest: XCTestCase {
         let navigationController = appDelegate.window!.rootViewController as! UINavigationController
         navigationController.popViewController(animated: true)
     }
-
 }

--- a/Example/Tests/MultipleInstancesTest.swift
+++ b/Example/Tests/MultipleInstancesTest.swift
@@ -68,7 +68,7 @@ class MultipleInstancesTest: XCTestCase {
         // Create an instance of a mock CBMCentralManager.
         let manager = CBMCentralManagerMock()
         
-        // Define the CBMPeripheralDelegate, which will wait until the serivces are
+        // Define the CBMPeripheralDelegate, which will wait until the services are
         // discovered and will discover characteristics.
         let peripheralDelegate = CBMPeripheralDelegateProxy()
         peripheralDelegate.didDiscoverServices = { peripheral, error in

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The library support [CocoaPods](https://github.com/CocoaPods/CocoaPods), [Cartha
 The library can also be included as SPM package. Simply add it in Xcode: *File -> Swift Packages -> Add package dependency*, 
 type *https://github.com/NordicSemiconductor/IOS-CoreBluetooth-Mock.git* and set required version, branch or commit.
 
-If you have *Swift.package* file, inculde the following dependency:
+If you have *Swift.package* file, include the following dependency:
 ```swift
 dependencies: [
     // [...]
@@ -136,7 +136,7 @@ properties to simulate central manager behavior:
 ### Basic
 
 `CBMCentralManagerMock.simulateInitialState(_ state: CBMManagerState)` -  this method should be called before
-any central manager instance was created. It defines the intial state of the mock central manager. By default, the manager is powered off.
+any central manager instance was created. It defines the initial state of the mock central manager. By default, the manager is powered off.
 
 `CBMCentralManager.simulatePowerOn()` - turns on the mock central manager.
 
@@ -149,7 +149,7 @@ mock peripheral. This method should be called when the manager is powered off, o
 clears the list of managers and peripherals bringing the mock manager to initial state.
 
 See [AppDelegate.swift](Example/nRFBlinky/AppDelegate.swift#L48) for reference. In the sample app the mock implementation is
-used only in UI Tests, which lauch the app with `mocking-enabled` parameter (see [here](Example/UI%20Tests/UITests.swift#L42)),
+used only in UI Tests, which launch the app with `mocking-enabled` parameter (see [here](Example/UI%20Tests/UITests.swift#L42)),
 but can be easily modified to use it every time it is launched on a simulator or a device.
 
 ### Peripheral specs
@@ -191,7 +191,7 @@ with `CBMCentralManagerOptionRestoreIdentifierKey` option. The map returned will
 `centralManager(:willRestoreState:)` callback in central manager's delegate.
 
 `CBMCentralManagerMock.simulateFeaturesSupport` - this closure will be used to emulate Bluetooth features supported
-by the manager. It is availalbe on iOS 13+, tvOS 13+ or watchOS 6+.
+by the manager. It is available on iOS 13+, tvOS 13+ or watchOS 6+.
 
 `CBMCentralManagerMock.simulateAuthorization(:)` - Simulates the current authorization state of a Core Bluetooth manager.
 When any value other than `.allowedAlways` is returned, the `CBMCentralManager` will change state to `CBMManagerState.unauthorized`.
@@ -225,7 +225,7 @@ A simplified proprietary service by Nordic Semiconductor, containing two charact
 ## Requirements:
 - An iOS device with BLE capabilities, or a simulator (to run the mock).
 - A [Development Kit](https://www.nordicsemi.com/Software-and-Tools/Development-Kits) (unless testing mock).
-- The Blinky example firmware to flash on the Development Kit. For your conveninence, we have bundled two firmwares in this project under the Firmwares directory.
+- The Blinky example firmware to flash on the Development Kit. For your convenience, we have bundled two firmwares in this project under the Firmwares directory.
 - To get the latest firmwares and check the source code, you may go directly to our [Developers website](http://developer.nordicsemi.com/nRF5_SDK/) and download the SDK version you need, then you can find the source code and hex files to the blinky demo in the directory `/examples/ble_peripheral/ble_app_blinky/`
 - The LBS (LED Button Service) is also supported in nRF Connect SDK: [here](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/samples/bluetooth/peripheral_lbs/README.html).
 -  More information about the nRFBlinky example firmware can be found in the [documentation](https://infocenter.nordicsemi.com/topic/sdk_nrf5_v17.0.2/ble_sdk_app_blinky.html?cp=8_1_4_2_2_3).


### PR DESCRIPTION
- Fix README.md typos

- Fix `CBMAttributes` typos

- Fix `CBMCentralManager` typos

- Fix `CBMCentralManagerMock` typos

- Fix `CBMPeripheralSpec` typos

- Remove whitespace in `FailedConnectionTest`

- Fix typo in `MultipleInstancesTest`