### PR TITLE
Bug fix: Returning peripheral name fixed

### DIFF
--- a/CoreBluetoothMock/Classes/CBMCentralManagerMock.swift
+++ b/CoreBluetoothMock/Classes/CBMCentralManagerMock.swift
@@ -764,9 +764,6 @@ open class CBMPeripheralMock: CBMPeer, CBMPeripheral {
     /// A flag set to <i>true</i> when the device was scanned
     /// at least once.
     fileprivate var wasScanned: Bool = false
-    /// A flag set to <i>true</i> when the device was connected
-    /// and iOS had chance to read device name.
-    fileprivate var wasConnected: Bool = false
     
     open var delegate: CBMPeripheralDelegate?
     
@@ -778,7 +775,7 @@ open class CBMPeripheralMock: CBMPeer, CBMPeripheral {
         // return nil. When scanning continued, the Local Name from the
         // advertisement data is returned. When the device was connected, the
         // central reads the Device Name characteristic and returns cached value.
-        return wasConnected ?
+        return mock.wasConnected ?
             mock.name :
             wasScanned ?
                 mock.advertisementData?[CBMAdvertisementDataLocalNameKey] as? String :
@@ -831,6 +828,7 @@ open class CBMPeripheralMock: CBMPeer, CBMPeripheral {
                 if case .success = result {
                     self.state = .connected
                     self._canSendWriteWithoutResponse = true
+                    self.mock.wasConnected = true
                     self.mock.virtualConnections += 1
                 } else {
                     self.state = .disconnected

--- a/CoreBluetoothMock/Classes/CBMPeripheralSpec.swift
+++ b/CoreBluetoothMock/Classes/CBMPeripheralSpec.swift
@@ -99,6 +99,11 @@ public class CBMPeripheralSpec {
     /// multiple apps. When this drops to 0, the device is physically
     /// disconnected.
     internal var virtualConnections: Int
+    /// This flag indicates whether the device was connected and cached
+    /// by the system.
+    ///
+    /// On the first connection iOS reads and caches Device Name characteristic.
+    internal var wasConnected: Bool
     
     private init(
         identifier: UUID,
@@ -126,6 +131,7 @@ public class CBMPeripheralSpec {
         self.connectionInterval = connectionInterval
         self.mtu = mtu
         self.connectionDelegate = connectionDelegate
+        self.wasConnected = isInitiallyConnected
     }
     
     /// Creates a `MockPeripheral.Builder` instance.


### PR DESCRIPTION
This PR fixes #78.

After the device is scanned, the `peripheral.name` returns the local name from the advertising packet under `CBMAdvertisementDataLocalNameKey`. From first connection, when the iOS discovers services and reads the *Device Name* characteristic, that name is returned and cached.