### PR TITLE
Add option CBConnectPeripheralOptionEnableTransportBridgingKey

### DIFF
--- a/CoreBluetoothMock/CBMManagerTypes.swift
+++ b/CoreBluetoothMock/CBMManagerTypes.swift
@@ -243,3 +243,15 @@ public let CBMConnectPeripheralOptionNotifyOnDisconnectionKey = CBConnectPeriphe
 /// most recently in the foreground receives the alert. If the key isn’t specified, the default
 /// value is `false`.
 public let CBMConnectPeripheralOptionNotifyOnNotificationKey = CBConnectPeripheralOptionNotifyOnNotificationKey
+/// A Boolean value that specifies whether the system should to connect non-GATT profiles
+/// on classic Bluetooth devices, if there is a low energy GATT connection to the same device.
+///
+/// If `true`, the system  instructs the system to bring up classic transport profiles when a
+/// low energy transport peripheral connects.
+///
+/// The value for this key is an `NSNumber` object. If the key isn’t specified, the default
+/// value is `false`.
+#if !os(macOS)
+@available(iOS 13.0, tvOS 13.0, watchOS 6.0, *)
+public let CBMConnectPeripheralOptionEnableTransportBridgingKey = CBConnectPeripheralOptionEnableTransportBridgingKey
+#endif


### PR DESCRIPTION
The CBConnectPeripheralOptionEnableTransportBridgingKey option tells the system to connect non-GATT profiles on classic Bluetooth devices, if there is a low energy GATT connection to the same device.