### PR TITLE
KVO Support

### DIFF
--- a/CoreBluetoothMock/CBMCentralManager.swift
+++ b/CoreBluetoothMock/CBMCentralManager.swift
@@ -92,7 +92,7 @@ open class CBMCentralManager: NSObject {
     
     /// Whether or not the central is currently scanning.
     @available(iOS 9.0, *)
-    open var isScanning: Bool { return false }
+    @objc open var isScanning: Bool { return false }
     
     /// The current authorization status for using Bluetooth.
     ///

--- a/CoreBluetoothMock/CBMCentralManager.swift
+++ b/CoreBluetoothMock/CBMCentralManager.swift
@@ -92,7 +92,7 @@ open class CBMCentralManager: NSObject {
     
     /// Whether or not the central is currently scanning.
     @available(iOS 9.0, *)
-    @objc open var isScanning: Bool { return false }
+    @objc dynamic open internal(set) var isScanning: Bool = false
     
     /// The current authorization status for using Bluetooth.
     ///

--- a/CoreBluetoothMock/CBMCentralManagerMock.swift
+++ b/CoreBluetoothMock/CBMCentralManagerMock.swift
@@ -81,7 +81,7 @@ open class CBMCentralManagerMock: CBMCentralManager {
             // ...stop scanning if state changed to any other state
             // than `.poweredOn`. Also, forget all peripherals.
             if manager.state != .poweredOn {
-                manager._isScanning = false
+                manager.isScanning = false
                 manager.scanFilter = nil
                 manager.scanOptions = nil
                 manager.peripherals.values.forEach { $0.closeManager() }
@@ -289,12 +289,11 @@ open class CBMCentralManagerMock: CBMCentralManager {
         }
     }
     /// A flag set to true when the manager is scanning for mock Bluetooth LE devices.
-    @objc private var _isScanning: Bool
+//    @objc private var isScanning: Bool
     
     // MARK: - Initializers
     
     public init() {
-        self._isScanning = false
         self.queue = DispatchQueue.main
         super.init(true)
         initialize()
@@ -302,7 +301,6 @@ open class CBMCentralManagerMock: CBMCentralManager {
     
     public init(delegate: CBMCentralManagerDelegate?,
                 queue: DispatchQueue?) {
-        self._isScanning = false
         self.queue = queue ?? DispatchQueue.main
         super.init(true)
         self.delegate = delegate
@@ -313,7 +311,6 @@ open class CBMCentralManagerMock: CBMCentralManager {
     public init(delegate: CBMCentralManagerDelegate?,
                 queue: DispatchQueue?,
                 options: [String : Any]?) {
-        self._isScanning = false
         self.queue = queue ?? DispatchQueue.main
         super.init(true)
         self.delegate = delegate
@@ -653,9 +650,7 @@ open class CBMCentralManagerMock: CBMCentralManager {
         }
         return CBMCentralManagerMock.managerState
     }
-    open override var isScanning: Bool {
-        return _isScanning
-    }
+    
     
     @available(iOS, introduced: 13.0, deprecated: 13.1)
     @available(macOS, introduced: 10.15)
@@ -686,7 +681,7 @@ open class CBMCentralManagerMock: CBMCentralManager {
                                           options: [String : Any]? = nil) {
         // Central manager must be in powered on state.
         guard ensurePoweredOn() else { return }
-        _isScanning = true
+        isScanning = true
         scanFilter = serviceUUIDs
         scanOptions = options
     }
@@ -694,7 +689,7 @@ open class CBMCentralManagerMock: CBMCentralManager {
     open override func stopScan() {
         // Central manager must be in powered on state.
         guard ensurePoweredOn() else { return }
-        _isScanning = false
+        isScanning = false
         scanFilter = nil
         scanOptions = nil
         peripherals.values.forEach { $0.wasScanned = false }

--- a/CoreBluetoothMock/CBMCentralManagerMock.swift
+++ b/CoreBluetoothMock/CBMCentralManagerMock.swift
@@ -123,6 +123,7 @@ open class CBMCentralManagerMock: CBMCentralManager {
     ///   - config: Advertisement configuration to start.
     ///   - mock: The advertising mock peripheral.
     private static func startAdvertising(_ config: CBMAdvertisementConfig, for mock: CBMPeripheralSpec) {
+        
         // A valid advertising config is a single time advertisement (delay > 0),
         // or a periodic one (interval > 0) (or both - delayed periodic advertisement).
         // Not to be mistaken with "Periodic Advertisement" from Advertising Extension.
@@ -288,7 +289,7 @@ open class CBMCentralManagerMock: CBMCentralManager {
         }
     }
     /// A flag set to true when the manager is scanning for mock Bluetooth LE devices.
-    private var _isScanning: Bool
+    @objc private var _isScanning: Bool
     
     // MARK: - Initializers
     

--- a/CoreBluetoothMock/CBMCentralManagerMock.swift
+++ b/CoreBluetoothMock/CBMCentralManagerMock.swift
@@ -875,7 +875,7 @@ open class CBMCentralManagerMock: CBMCentralManager {
 /// This implementation will be used when creating peripherals by ``CBMCentralManagerMock``.
 ///
 /// Unless required, this class should not be accessed directly, but rather by the common protocol ``CBMPeripheral``.
-open class CBMPeripheralMock: CBMPeer, CBMPeripheral {
+@objc open class CBMPeripheralMock: CBMPeer, CBMPeripheral {
     /// The parent central manager.
     private let manager: CBMCentralManagerMock
     /// The dispatch queue to call delegate methods on.
@@ -919,7 +919,7 @@ open class CBMPeripheralMock: CBMPeer, CBMPeripheral {
         return _canSendWriteWithoutResponse
     }
     open private(set) var ancsAuthorized: Bool = false
-    open fileprivate(set) var state: CBMPeripheralState = .disconnected
+    @objc dynamic open fileprivate(set) var state: CBMPeripheralState = .disconnected
     open private(set) var services: [CBMService]? = nil
     
     // MARK: Initializers

--- a/CoreBluetoothMock/CBMCentralManagerMock.swift
+++ b/CoreBluetoothMock/CBMCentralManagerMock.swift
@@ -288,8 +288,6 @@ open class CBMCentralManagerMock: CBMCentralManager {
             CBMCentralManagerMock.managers.contains { $0.ref == self }
         }
     }
-    /// A flag set to true when the manager is scanning for mock Bluetooth LE devices.
-//    @objc private var isScanning: Bool
     
     // MARK: - Initializers
     

--- a/CoreBluetoothMock/CBMCentralManagerNative.swift
+++ b/CoreBluetoothMock/CBMCentralManagerNative.swift
@@ -526,7 +526,7 @@ public class CBMPeripheralNative: CBMPeer, CBMPeripheral {
     }
     #endif
     
-    fileprivate let peripheral: CBPeripheral
+    public let peripheral: CBPeripheral
     
     fileprivate init(_ peripheral: CBPeripheral) {
         self.peripheral = peripheral

--- a/CoreBluetoothMock/CBMPeripheralPreview.swift
+++ b/CoreBluetoothMock/CBMPeripheralPreview.swift
@@ -39,7 +39,7 @@ import CoreBluetooth
 /// All ``CBMService``s are available immediately, without the need for service discovery.
 /// Bluetooth LE operations are NO OP. The device does not need to be scanned to
 /// be retrievable by any ``CBMCentralManagerMock`` instance.
-open class CBMPeripheralPreview: CBMPeripheral {
+@objc open class CBMPeripheralPreview: NSObject, CBMPeripheral {
     private let mock: CBMPeripheralSpec
     
     public let identifier: UUID
@@ -49,7 +49,7 @@ open class CBMPeripheralPreview: CBMPeripheral {
     public var services: [CBMService]?
     
     public var delegate: CBMPeripheralDelegate?
-    public internal(set) var state: CBMPeripheralState
+    @objc dynamic public internal(set) var state: CBMPeripheralState
     
     public let canSendWriteWithoutResponse: Bool = true
     public let ancsAuthorized: Bool = false
@@ -63,6 +63,7 @@ open class CBMPeripheralPreview: CBMPeripheral {
         self.mock = mock
         self.identifier = mock.identifier
         self.state = state
+        super.init()
         self.services = mock.services?.map { CBMService(copy: $0, for: self) }
         CBMCentralManagerMock.registerForPreviews(self)
     }
@@ -118,7 +119,7 @@ open class CBMPeripheralPreview: CBMPeripheral {
         fatalError("Not available")
     }
 }
-
+/*
 extension CBMPeripheralPreview: Hashable {
     
     public static func == (lhs: CBMPeripheralPreview, rhs: CBMPeripheralPreview) -> Bool {
@@ -130,3 +131,4 @@ extension CBMPeripheralPreview: Hashable {
     }
     
 }
+*/


### PR DESCRIPTION
- Who are we?
- Objective-C dinosaurs!
- What do we want?
- KVO!

Added @objc modificator to `isScanning` property to make it observable.

### Example
```swift
func setup() {
     obserwation = observe(\.cm?.isScanning,
                           options: [.old, .new],
                           changeHandler: { _, change in
            
        change.newValue?.flatMap { new in
            print("Is Scanning: \(new)")
        }
    )
}
```