### PR TITLE
Remove peripheral after disconnect

### DIFF
--- a/CoreBluetoothMock/CBMCentralManagerNative.swift
+++ b/CoreBluetoothMock/CBMCentralManagerNative.swift
@@ -89,6 +89,7 @@ public class CBMCentralManagerNative: CBMCentralManager {
             manager.delegate?.centralManager(manager,
                                              didDisconnectPeripheral: getPeripheral(peripheral),
                                              error: error)
+            removePeripheral(peripheral)
         }
         
         #if !os(macOS)
@@ -119,6 +120,10 @@ public class CBMCentralManagerNative: CBMCentralManager {
             let p = CBMPeripheralNative(peripheral)
             manager.peripherals[peripheral.identifier] = p
             return p
+        }
+
+        private func removePeripheral(_ peripheral: CBPeripheral) {
+            manager.peripherals[peripheral.identifier] = nil
         }
     }
     


### PR DESCRIPTION
If we don't remove the peripheral, it will be reused (containing the services currently present). This is not how `CBPeripheral` works, there will be no services present after a disconnect -> connect.