### PR TITLE
wrap CBPeripherals as CBMPeripheralNative on restore

### DIFF
--- a/CoreBluetoothMock/CBMCentralManagerNative.swift
+++ b/CoreBluetoothMock/CBMCentralManagerNative.swift
@@ -131,7 +131,15 @@ public class CBMCentralManagerNative: CBMCentralManager {
         
         func centralManager(_ central: CBCentralManager,
                             willRestoreState dict: [String : Any]) {
-            manager.delegate?.centralManager(manager, willRestoreState: dict)
+            var state = dict
+            
+            if let peripherals = dict[CBCentralManagerRestoredStatePeripheralsKey] as? [CBPeripheral] {
+                state[CBMCentralManagerRestoredStatePeripheralsKey] = peripherals.map {
+                    CBMPeripheralNative($0)
+                }
+            }
+                        
+            manager.delegate?.centralManager(manager, willRestoreState: state)
         }
     }
     


### PR DESCRIPTION
I found when trying to restore state that it was tricky as the state contains `CBPeripheral` objects, but the rest of the code more or less relies on `CBMPeripheral` everywhere. One option would be to make the `CBPeripheralNative.init` public, but I think manipulating the state is more consistent with the CoreBluetoothMock API in general.