### PR TITLE
Add internal thread-safe dictionary wrapper

### DIFF
--- a/CoreBluetoothMock/CBMCentralManagerMock.swift
+++ b/CoreBluetoothMock/CBMCentralManagerMock.swift
@@ -55,7 +55,7 @@ open class CBMCentralManagerMock: CBMCentralManager {
     /// Registered items can be accessed using any ``CBMCentralManagerMock``.
     private static var previewPeripherals: Set<CBMPeripheralPreview> = Set()
     /// A map of all current advertisements of all simulated peripherals.
-    private static var advertisementTimers: [CBMAdvertisementConfig : Timer] = [:]
+    private static var advertisementTimers = CBMDictionary<CBMAdvertisementConfig, Timer>()
     /// A mutex queue for managing managers.
     private static let mutex: DispatchQueue = DispatchQueue(label: "Mutex")
     /// The value of current authorization status for using Bluetooth.

--- a/CoreBluetoothMock/CBMCentralManagerNative.swift
+++ b/CoreBluetoothMock/CBMCentralManagerNative.swift
@@ -38,7 +38,7 @@ public class CBMCentralManagerNative: CBMCentralManager {
     var observation: NSKeyValueObservation?
     @objc dynamic private var manager: CBCentralManager!
     private var wrapper: CBCentralManagerDelegate!
-    private var peripherals: [UUID : CBMPeripheralNative] = [:]
+    private var peripherals = CBMDictionary<UUID, CBMPeripheralNative>()
     
     private class CBMCentralManagerDelegateWrapper: NSObject, CBCentralManagerDelegate {
         fileprivate weak var manager: CBMCentralManagerNative! // weak to avoid cyclic reference (#9)

--- a/CoreBluetoothMock/CBMDictionary.swift
+++ b/CoreBluetoothMock/CBMDictionary.swift
@@ -1,0 +1,132 @@
+/*
+* Copyright (c) 2020, Nordic Semiconductor
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice, this
+*    list of conditions and the following disclaimer.
+*
+* 2. Redistributions in binary form must reproduce the above copyright notice, this
+*    list of conditions and the following disclaimer in the documentation and/or
+*    other materials provided with the distribution.
+*
+* 3. Neither the name of the copyright holder nor the names of its contributors may
+*    be used to endorse or promote products derived from this software without
+*    specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+* IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+* INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+* NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+* PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+* WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+* ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+* POSSIBILITY OF SUCH DAMAGE.
+*/
+
+import Foundation
+
+/// A thread-safe dictionary implementation that uses a concurrent dispatch queue for synchronization.
+///
+/// - NOTE: This dictionary wrapper does not implement every possible operation and can be expanded as needed
+/// for future use
+class CBMDictionary<Key: Hashable, Value> {
+    private var dictStorage = [Key: Value]()
+    
+    /// A concurrent queue used for synchronizing access to the dictionary
+    private let queue = DispatchQueue(
+        label: "CoreBluetoothMock.CBMDictionary.\(UUID().uuidString)",
+        qos: .default,
+        attributes: .concurrent,
+        target: .global()
+    )
+    
+    subscript(key: Key) -> Value? {
+        get {
+            return queue.sync {
+                return dictStorage[key]
+            }
+        }
+        set {
+            queue.async(flags: .barrier) { [weak self] in
+                self?.dictStorage[key] = newValue
+            }
+        }
+    }
+    
+    /// A collection containing just the values of the dictionary.
+    ///
+    /// Uses a private queue to ensure thread-safe access when calling `.keys`
+    /// on the underlying dictionary.
+    var keys: Dictionary<Key, Value>.Keys {
+        return queue.sync {
+            return dictStorage.keys
+        }
+    }
+    
+    /// A collection containing just the values of the dictionary.
+    ///
+    /// Uses a private queue to ensure thread-safe access when calling `.values`
+    /// on the underlying dictionary.
+    var values: Dictionary<Key, Value>.Values {
+        return queue.sync {
+            return dictStorage.values
+        }
+    }
+    
+    /// Returns a new dictionary containing the key-value pairs of the dictionary that satisfy the given predicate.
+    ///
+    /// Uses a private queue to ensure thread-safe access when calling `.filter`
+    /// on the underlying dictionary.
+    ///
+    /// - Parameter isIncluded: A closure that takes a key-value pair as its argument and returns a Boolean value
+    /// indicating whether the pair should be included in the returned dictionary.
+    /// - Returns: A dictionary of the key-value pairs that isIncluded allows.
+    func filter(_ isIncluded: (Dictionary<Key, Value>.Element) throws -> Bool) rethrows -> [Key: Value] {
+        return try queue.sync {
+            return try dictStorage.filter(isIncluded)
+        }
+    }
+    
+    
+    /// Calls the given closure on each element in the sequence in the same order as a for-in loop.
+    ///
+    /// Uses a private queue to ensure thread-safe access when calling `.forEach`
+    /// on the underlying dictionary.
+    ///
+    /// - Parameter body: A closure that takes an element of the sequence as a parameter.
+    func forEach(_ body: (Dictionary<Key, Value>.Element) throws -> Void) rethrows {
+        try queue.sync {
+            try dictStorage.forEach(body)
+        }
+    }
+    
+    /// Removes the given key and its associated value from the dictionary.
+    ///
+    /// Uses a private queue to ensure thread-safe access when calling `.removeValue`
+    /// on the underlying dictionary.
+    ///
+    /// - Parameter key: The key to remove along with its associated value.
+    /// - Returns: The value that was removed, or nil if the key was not present in the dictionary.
+    @discardableResult
+    func removeValue(forKey key: Key) -> Value? {
+        return queue.sync(flags: .barrier) { [weak self] in
+            guard let self = self else { return nil }
+            return self.dictStorage.removeValue(forKey: key)
+        }
+    }
+    
+    /// Removes all key-value pairs from the dictionary
+    /// 
+    /// Uses a private queue to ensure thread-safe access when calling `.removeAll`
+    /// on the underlying dictionary.
+    func removeAll() {
+        queue.sync(flags: .barrier) { [weak self] in
+            self?.dictStorage.removeAll()
+        }
+    }
+}


### PR DESCRIPTION
To address issue #114, this PR includes an internal wrapper for `Dictionary` called `CBMDictionary`.

Some notes:
- The `CBMDictionary` does not attempt to include every possible dictionary operation - only what is needed by the current implementation of `CoreBluetoothMock`. 
- The private queue uses the default quality-of-service. I believe this is sufficient.

Running the same unit test in #114 100,000 times repeatedly passes successfully:

<img width="914" alt="image" src="https://github.com/user-attachments/assets/c4853764-a1e3-40bc-a0de-5048fcb8680e" />

Testing the performance of `CBMCentralManagerMock.simulatePeripherals([device])` with the `CBMDictionary` was promising. In 100 tests, the average time:
- CBMDictionary: `46.71` microseconds
- Dictionary (Current): `46.04` microseconds


