### PR TITLE
Add supervision timeout to `CBMPeriphalSpec`, make rssi deviation public and mutable

### DIFF
--- a/CoreBluetoothMock/CBMCentralManagerMock.swift
+++ b/CoreBluetoothMock/CBMCentralManagerMock.swift
@@ -68,7 +68,7 @@ open class CBMCentralManagerMock: CBMCentralManager {
     /// Returned RSSI values will be in range
     /// `(base RSSI - deviation)...(base RSSI + deviation)`.
     ///
-    /// Defaults to maximum value of 15 dBm
+    /// Defaults to 15 dBm.
     internal private(set) static var rssiDeviation: CBMProximity.Deviation = .default
     
     /// The global state of the Bluetooth adapter on the device.
@@ -247,7 +247,7 @@ open class CBMCentralManagerMock: CBMCentralManager {
                     peripheral.lastAdvertisedName = config.data[CBAdvertisementDataLocalNameKey] as? String ?? peripheral.lastAdvertisedName
                     // Emulate RSSI based on proximity. Apply some deviation.
                     let rssi = mock.proximity.RSSI
-                    let delta = CBMCentralManagerMock.rssiDeviation.rawValue
+                    let delta = CBMCentralManagerMock.rssiDeviation.value
                     let deviation = Int.random(in: -delta...delta)
                     manager.delegate?.centralManager(manager, didDiscover: peripheral,
                                                      advertisementData: config.data,
@@ -390,9 +390,9 @@ open class CBMCentralManagerMock: CBMCentralManager {
         bluetoothAuthorization = authorization.rawValue
     }
     
-    /// Simulates the degree of variability in the reported RSSI
+    /// Simulates the degree of variability in the reported RSSI.
     ///
-    /// - NOTE: For unit testing, it is recommended to set this value to `.none`
+    /// - NOTE: For unit testing, it is recommended to set this value to `.none`.
     public static func simulateRSSIDeviation(_ deviation: CBMProximity.Deviation) {
         rssiDeviation = deviation
     }
@@ -1564,7 +1564,7 @@ open class CBMCentralManagerMock: CBMCentralManager {
         queue.async { [weak self] in
             if let self = self, self.state == .connected {
                 let rssi = self.mock.proximity.RSSI
-                let delta = CBMCentralManagerMock.rssiDeviation.rawValue
+                let delta = CBMCentralManagerMock.rssiDeviation.value
                 let deviation = Int.random(in: -delta...delta)
                 self.delegate?.peripheral(self, didReadRSSI: (rssi + deviation) as NSNumber,
                                           error: nil)

--- a/CoreBluetoothMock/CBMCentralManagerMock.swift
+++ b/CoreBluetoothMock/CBMCentralManagerMock.swift
@@ -69,7 +69,7 @@ open class CBMCentralManagerMock: CBMCentralManager {
     /// `(base RSSI - deviation)...(base RSSI + deviation)`.
     ///
     /// Defaults to maximum value of 15 dBm
-    internal private(set) static var rssiDeviation: CBMProximity.Deviation = .max
+    internal private(set) static var rssiDeviation: CBMProximity.Deviation = .default
     
     /// The global state of the Bluetooth adapter on the device.
     fileprivate private(set) static var managerState: CBMManagerState = .poweredOff {
@@ -377,6 +377,8 @@ open class CBMCentralManagerMock: CBMCentralManager {
         }
         // Set the manager state to powered Off.
         managerState = .poweredOff
+        // Reset the RSSI deviation to the default
+        rssiDeviation = .default
         peripherals.removeAll()
     }
     

--- a/CoreBluetoothMock/CBMCentralManagerMock.swift
+++ b/CoreBluetoothMock/CBMCentralManagerMock.swift
@@ -887,10 +887,6 @@ open class CBMCentralManagerMock: CBMCentralManager {
     /// can be written without response in a loop, without
     /// waiting for ``CBMPeripheral/canSendWriteWithoutResponse``.
     private let bufferSize = 20
-    /// The supervision timeout is a time after which a device realizes
-    /// that a connected peer has disconnected, had there been no signal
-    /// from it.
-    private let supervisionTimeout = 4.0
     /// The current buffer size.
     private var availableWriteWithoutResponseBuffer: Int
     private var _canSendWriteWithoutResponse: Bool = false
@@ -1026,8 +1022,8 @@ open class CBMCentralManagerMock: CBMCentralManager {
         // If a device disconnected with a timeout, the central waits
         // for the duration of supervision timeout before accepting
         // disconnection.
-        if let error = error as? CBMError, error.code == .connectionTimeout {
-            interval = supervisionTimeout
+        if let error = error as? CBMError, error.code == .connectionTimeout, let timeout = mock.supervisionTimeout {
+            interval = timeout
         }
         queue.asyncAfter(deadline: .now() + interval) { [weak self] in
             if let self = self, CBMCentralManagerMock.managerState == .poweredOn {

--- a/CoreBluetoothMock/CBMCentralManagerMock.swift
+++ b/CoreBluetoothMock/CBMCentralManagerMock.swift
@@ -39,7 +39,9 @@ open class CBMCentralManagerMock: CBMCentralManager {
     ///
     /// Returned RSSI values will be in range
     /// `(base RSSI - deviation)...(base RSSI + deviation)`.
-    fileprivate static let rssiDeviation = 15 // dBm
+    ///
+    /// Defaults to maximum value of 15 dBm
+    public static var rssiDeviation: CBMProximity.Deviation = .max
     
     /// A list of all mock managers instantiated by user.
     private static var managers: [WeakRef<CBMCentralManagerMock>] = []
@@ -242,7 +244,7 @@ open class CBMCentralManagerMock: CBMCentralManager {
                     peripheral.lastAdvertisedName = config.data[CBAdvertisementDataLocalNameKey] as? String ?? peripheral.lastAdvertisedName
                     // Emulate RSSI based on proximity. Apply some deviation.
                     let rssi = mock.proximity.RSSI
-                    let delta = CBMCentralManagerMock.rssiDeviation
+                    let delta = CBMCentralManagerMock.rssiDeviation.rawValue
                     let deviation = Int.random(in: -delta...delta)
                     manager.delegate?.centralManager(manager, didDiscover: peripheral,
                                                      advertisementData: config.data,
@@ -1550,7 +1552,7 @@ open class CBMCentralManagerMock: CBMCentralManager {
         queue.async { [weak self] in
             if let self = self, self.state == .connected {
                 let rssi = self.mock.proximity.RSSI
-                let delta = CBMCentralManagerMock.rssiDeviation
+                let delta = CBMCentralManagerMock.rssiDeviation.rawValue
                 let deviation = Int.random(in: -delta...delta)
                 self.delegate?.peripheral(self, didReadRSSI: (rssi + deviation) as NSNumber,
                                           error: nil)

--- a/CoreBluetoothMock/CBMCentralManagerMock.swift
+++ b/CoreBluetoothMock/CBMCentralManagerMock.swift
@@ -35,13 +35,7 @@ import CoreBluetooth
 /// This implementation will interact only with mock peripherals created using
 /// ``CBMPeripheralSpec/simulatePeripheral(identifier:proximity:)``.
 open class CBMCentralManagerMock: CBMCentralManager {
-    /// Mock RSSI deviation.
-    ///
-    /// Returned RSSI values will be in range
-    /// `(base RSSI - deviation)...(base RSSI + deviation)`.
-    ///
-    /// Defaults to maximum value of 15 dBm
-    public static var rssiDeviation: CBMProximity.Deviation = .max
+
     
     /// A list of all mock managers instantiated by user.
     private static var managers: [WeakRef<CBMCentralManagerMock>] = []
@@ -68,6 +62,15 @@ open class CBMCentralManagerMock: CBMCentralManager {
             notifyManagers()
         }
     }
+    
+    /// Mock RSSI deviation.
+    ///
+    /// Returned RSSI values will be in range
+    /// `(base RSSI - deviation)...(base RSSI + deviation)`.
+    ///
+    /// Defaults to maximum value of 15 dBm
+    internal private(set) static var rssiDeviation: CBMProximity.Deviation = .max
+    
     /// The global state of the Bluetooth adapter on the device.
     fileprivate private(set) static var managerState: CBMManagerState = .poweredOff {
         didSet {
@@ -383,6 +386,13 @@ open class CBMCentralManagerMock: CBMCentralManager {
     @available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
     public static func simulateAuthorization(_ authorization: CBMManagerAuthorization) {
         bluetoothAuthorization = authorization.rawValue
+    }
+    
+    /// Simulates the degree of variability in the reported RSSI
+    ///
+    /// - NOTE: For unit testing, it is recommended to set this value to `.none`
+    public static func simulateRSSIDeviation(_ deviation: CBMProximity.Deviation) {
+        rssiDeviation = deviation
     }
     
     /// This simulation method is called when a mock central manager was

--- a/CoreBluetoothMock/CBMPeripheralSpec.swift
+++ b/CoreBluetoothMock/CBMPeripheralSpec.swift
@@ -50,12 +50,25 @@ public enum CBMProximity {
         }
     }
     
-    /// The amount the proximity should randomly deviate when reporting RSSI
-    public enum Deviation: Int {
-        /// Zero deviation
-        case none = 0
-        /// +/- 15 dBm
-        case `default` = 15
+    /// The amount the proximity should randomly deviate when reporting RSSI.
+    public enum Deviation {
+        /// Zero deviation from a proximity's preset RSSI.
+        case none
+        /// +/- 15 dBm deviation from a proximity's preset RSSI.
+        case `default`
+        /// A custom deviation from a proximity's preset RSSI.
+        ///
+        /// This should be a positive value. If a negative value is provided,
+        /// its absolute value is used when determining RSSI deviation.
+        case custom(_ deviation: Int)
+        
+        internal var value: Int {
+            switch self {
+            case .none:              return 0
+            case .default:           return 15
+            case .custom(let value): return abs(value)
+            }
+        }
     }
 }
 
@@ -494,7 +507,7 @@ public class CBMPeripheralSpec {
                               services: [CBMServiceMock],
                               delegate: CBMPeripheralSpecDelegate?,
                               connectionInterval: TimeInterval = 0.045,
-                              supervisionTimeout: Double = 4.0,
+                              supervisionTimeout: TimeInterval = 4.0,
                               mtu: Int = 23) -> Builder {
             self.name = name
             self.services = services

--- a/CoreBluetoothMock/CBMPeripheralSpec.swift
+++ b/CoreBluetoothMock/CBMPeripheralSpec.swift
@@ -55,7 +55,7 @@ public enum CBMProximity {
         /// Zero deviation
         case none = 0
         /// +/- 15 dBm
-        case max = 15
+        case `default` = 15
     }
 }
 

--- a/CoreBluetoothMock/CBMPeripheralSpec.swift
+++ b/CoreBluetoothMock/CBMPeripheralSpec.swift
@@ -58,7 +58,7 @@ public enum CBMProximity {
         case `default`
         /// A custom deviation from a proximity's preset RSSI.
         ///
-        /// This should be a positive value. If a negative value is provided,
+        /// This should be zero or greater. If a negative value is provided,
         /// its absolute value is used when determining RSSI deviation.
         case custom(_ deviation: Int)
         

--- a/CoreBluetoothMock/CBMPeripheralSpec.swift
+++ b/CoreBluetoothMock/CBMPeripheralSpec.swift
@@ -206,8 +206,8 @@ public class CBMPeripheralSpec {
         advertisement: [CBMAdvertisementConfig]?,
         services: [CBMServiceMock]?,
         connectionInterval: TimeInterval?,
-        mtu: Int?,
         supervisionTimeout: TimeInterval?,
+        mtu: Int?,
         connectionDelegate: CBMPeripheralSpecDelegate?
     ) {
         self.identifier = identifier
@@ -529,8 +529,8 @@ public class CBMPeripheralSpec {
                 advertisement: advertisement,
                 services: services,
                 connectionInterval: connectionInterval,
-                mtu: mtu,
                 supervisionTimeout: supervisionTimeout,
+                mtu: mtu,
                 connectionDelegate: connectionDelegate
             )
         }

--- a/CoreBluetoothMock/CBMPeripheralSpec.swift
+++ b/CoreBluetoothMock/CBMPeripheralSpec.swift
@@ -168,6 +168,10 @@ public class CBMPeripheralSpec {
     /// The maximum value length for Write Without Response is MTU - 3 bytes, as 3 bytes
     /// are reserved for the Handle number and Op Code on the GATT layer.
     public let mtu: Int?
+    /// The supervision timeout is a time after which a device realizes
+    /// that a connected peer has disconnected, had there been no signal
+    /// from it.
+    public let supervisionTimeout: TimeInterval?
     /// The delegate that will handle connection requests.
     public let connectionDelegate: CBMPeripheralSpecDelegate?
     /// A flag indicating whether the device is connected.
@@ -195,6 +199,7 @@ public class CBMPeripheralSpec {
         services: [CBMServiceMock]?,
         connectionInterval: TimeInterval?,
         mtu: Int?,
+        supervisionTimeout: TimeInterval?,
         connectionDelegate: CBMPeripheralSpecDelegate?
     ) {
         self.identifier = identifier
@@ -206,6 +211,7 @@ public class CBMPeripheralSpec {
         self.services = services
         self.connectionInterval = connectionInterval
         self.mtu = mtu
+        self.supervisionTimeout = supervisionTimeout
         self.connectionDelegate = connectionDelegate
         self.wasConnected = isInitiallyConnected
     }
@@ -383,6 +389,10 @@ public class CBMPeripheralSpec {
         /// The maximum value length for Write Without Response is
         /// MTU - 3 bytes.
         private var mtu: Int? = nil
+        /// The supervision timeout is a time after which a device realizes
+        /// that a connected peer has disconnected, had there been no signal
+        /// from it.
+        private var supervisionTimeout: TimeInterval? = 4.0
         /// The delegate that will handle connection requests.
         private var connectionDelegate: CBMPeripheralSpecDelegate?
         
@@ -431,6 +441,9 @@ public class CBMPeripheralSpec {
         ///   - connectionDelegate: The connection delegate that will handle
         ///                         GATT requests.
         ///   - connectionInterval: Connection interval, in seconds.
+        ///   - supervisionTimeout: A time after which a device realizes
+        ///                         that a connected peer has disconnected, had 
+        ///                         there been no signal from it.
         ///   - mtu: The MTU (Maximum Transfer Unit). Min 23 (default), max 517.
         ///          The maximum value length for Write Without Response is
         ///          MTU - 3 bytes (3 bytes are used by GATT for handle and
@@ -439,11 +452,13 @@ public class CBMPeripheralSpec {
                                 services: [CBMServiceMock],
                                 delegate: CBMPeripheralSpecDelegate?,
                                 connectionInterval: TimeInterval = 0.045,
+                                supervisionTimeout: TimeInterval = 4.0,
                                 mtu: Int = 23) -> Builder {
             self.name = name
             self.services = services
             self.connectionDelegate = delegate
             self.connectionInterval = connectionInterval
+            self.supervisionTimeout = supervisionTimeout
             self.mtu = max(23, min(517, mtu))
             self.isInitiallyConnected = false
             return self
@@ -460,6 +475,9 @@ public class CBMPeripheralSpec {
         ///   - connectionDelegate: The connection delegate that will handle
         ///                         GATT requests.
         ///   - connectionInterval: Connection interval, in seconds.
+        ///   - supervisionTimeout: A time after which a device realizes
+        ///                         that a connected peer has disconnected, had
+        ///                         there been no signal from it.
         ///   - mtu: The MTU (Maximum Transfer Unit). Min 23 (default), max 517.
         ///          The maximum value length for Write Without Response is
         ///          MTU - 3 bytes (3 bytes are used by GATT for handle and
@@ -468,11 +486,13 @@ public class CBMPeripheralSpec {
                               services: [CBMServiceMock],
                               delegate: CBMPeripheralSpecDelegate?,
                               connectionInterval: TimeInterval = 0.045,
+                              supervisionTimeout: Double = 4.0,
                               mtu: Int = 23) -> Builder {
             self.name = name
             self.services = services
             self.connectionDelegate = delegate
             self.connectionInterval = connectionInterval
+            self.supervisionTimeout = supervisionTimeout
             self.mtu = max(23, min(517, mtu))
             self.isInitiallyConnected = proximity != .outOfRange
             self.isKnown = true
@@ -502,6 +522,7 @@ public class CBMPeripheralSpec {
                 services: services,
                 connectionInterval: connectionInterval,
                 mtu: mtu,
+                supervisionTimeout: supervisionTimeout,
                 connectionDelegate: connectionDelegate
             )
         }

--- a/CoreBluetoothMock/CBMPeripheralSpec.swift
+++ b/CoreBluetoothMock/CBMPeripheralSpec.swift
@@ -49,6 +49,14 @@ public enum CBMProximity {
         case .outOfRange: return 127
         }
     }
+    
+    /// The amount the proximity should randomly deviate when reporting RSSI
+    public enum Deviation: Int {
+        /// Zero deviation
+        case none = 0
+        /// +/- 15 dBm
+        case max = 15
+    }
 }
 
 /// Advertisement configuration.


### PR DESCRIPTION
Two changes to make the library more friendly for unit testing to address #116.

1. RSSI deviation is now an `internal private(set)` mutable variable that can be set via a new public function `simulateRSSIDeviation`. It is serves as configuration to `CBCentralManagerMock`. A new internal enum `Deviation` has been added to `CBMPromixity` to limit the possible values to either `.default` which is the current implementation of `+/- 15 dBm` and `.none` which is 0. 

```swift
CBMCentralManagerMock.simulateRSSIDeviation(.none)
```

2. The supervisionTimeout has been added to `CBMPeripheralSpec` so that it can be optionally initialized with `.connectable` similar to the `mtu` and `connectionInterval`. Default value is `4.0` seconds to match the existing private implementation.

```swift
.connectable(
    name: "Test_Device",
    services: [],
    delegate: self,
    connectionInterval: 0.01,
    supervisionTimeout: 0,
    mtu: 32
)
```
These are non-breaking changes that only add functionality to the existing API. Existing clients are unaffected.

Adding the above changes to the unit test in #116 allow the tests to pass without any delays

Single test
```
Test Case '-[BluetoothMockExampleTests.BluetoothDelegateTests testPeripheralConnectThenOutOfRange]' passed (0.048 seconds).
Test Suite 'BluetoothDelegateTests' passed at 2025-03-10 12:52:04.728.
	 Executed 1 test, with 0 failures (0 unexpected) in 0.048 (0.049) seconds
```
  
100,000 Repeated Tests
```
Test Suite 'BluetoothDelegateTests' passed at 2025-03-10 13:35:49.387.
	 Executed 100000 tests, with 0 failures (0 unexpected) in 1147.365 (1164.023) seconds
```