### PR TITLE
[Breaking] Typo in `CBMServiceMock` init param name fixed

### DIFF
--- a/CoreBluetoothMock/CBMAttributes.swift
+++ b/CoreBluetoothMock/CBMAttributes.swift
@@ -150,11 +150,11 @@ open class CBMServiceMock: CBMService {
     ///   - includedServices: Optional list of included services.
     ///   - characteristics: Optional list of characteristics.
     public convenience init(type uuid: CBMUUID, primary isPrimary: Bool,
-                            includedService: CBMServiceMock...,
+                            includedServices: CBMServiceMock...,
                             characteristics: CBMCharacteristicMock...) {
         self.init(type: uuid,
                   primary: isPrimary,
-                  includedService: includedService,
+                  includedServices: includedServices,
                   characteristics: characteristics)
     }
 
@@ -165,11 +165,11 @@ open class CBMServiceMock: CBMService {
     ///   - includedServices: Optional array of included services.
     ///   - characteristics: Optional array of characteristics.
     public init(type uuid: CBMUUID, primary isPrimary: Bool,
-                includedService: [CBMServiceMock]? = nil,
+                includedServices: [CBMServiceMock]? = nil,
                 characteristics: [CBMCharacteristicMock]? = nil) {
         super.init(type: uuid, primary: isPrimary)
-        if let includedService = includedService {
-            self._includedServices = includedService
+        if let includedServices = includedServices {
+            self._includedServices = includedServices
         }
         if let characteristics = characteristics {
             self._characteristics = characteristics

--- a/CoreBluetoothMock/Documentation.docc/KnownIssues.md
+++ b/CoreBluetoothMock/Documentation.docc/KnownIssues.md
@@ -4,7 +4,7 @@ Known issues when using **CoreBluetoothMock** framework instead of native **Core
 
 ## Overview
 
-By design, the library should behave exatly the same as the native implementation and no
+By design, the library should behave exactly the same as the native implementation and no
 code changes above those mentioned in <doc:Migration-guide> should be necessary.
 
 However, to make mocking possible, some tradeoffs were made.

--- a/Example/nRFBlinky/Models/BlinkyManager.swift
+++ b/Example/nRFBlinky/Models/BlinkyManager.swift
@@ -30,6 +30,9 @@
 
 import Foundation
 
+/// A manager responsible for scanning, connecting and managing Blinky peripherals.
+///
+/// If allows connecting to a single device at a time.
 class BlinkyManager {
     /// Underlying central manager.
     private var centralManager: CBCentralManager!

--- a/Example/nRFBlinky/Models/BlinkyPeripheral.swift
+++ b/Example/nRFBlinky/Models/BlinkyPeripheral.swift
@@ -71,6 +71,7 @@ class BlinkyPeripheral: NSObject, CBPeripheralDelegate {
     ///   - peripheral: The underlying peripheral.
     ///   - data: The latest advertisement data of the device.
     ///   - currentRSSI: The most recent RSSI value.
+    ///   - manager: The ``BlinkyManager`` instance.
     init(withPeripheral peripheral: CBPeripheral,
          advertisementData data: [String : Any],
          andRSSI currentRSSI: NSNumber,


### PR DESCRIPTION
This PR fixes several documentation issues. One of them was actally the API mistake, where the parameter of `CBMServiceMock` was in singular form, not plural. Sorry for that!
Luckily, it was related to included services, so hopefully no one ever used it.