### PR TITLE
Bugfix: State restoration for mock

### DIFF
--- a/CoreBluetoothMock/CBMCentralManagerMock.swift
+++ b/CoreBluetoothMock/CBMCentralManagerMock.swift
@@ -399,7 +399,7 @@ open class CBMCentralManagerMock: CBMCentralManager {
     
     /// Simulates the degree of variability in the reported RSSI.
     ///
-    /// - NOTE: For unit testing, it is recommended to set this value to `.none`.
+    /// - Note: For unit testing, it is recommended to set this value to ``CBMProximity/Deviation/none``.
     public static func simulateRSSIDeviation(_ deviation: CBMProximity.Deviation) {
         rssiDeviation = deviation
     }
@@ -600,8 +600,9 @@ open class CBMCentralManagerMock: CBMCentralManager {
     }
     
     /// Method called when a peripheral becomes available (in range).
+    ///
     /// If there is a pending connection request, it will connect.
-    /// - Parameter peripheral: The peripheral that came in range. 
+    /// - Parameter peripheral: The peripheral that came in range.
     internal static func peripheralBecameAvailable(_ peripheral: CBMPeripheralSpec) {
         let existingManagers = CBMCentralManagerMock.mutex.sync {
             managers.compactMap { $0.ref }

--- a/CoreBluetoothMock/CBMCentralManagerMock.swift
+++ b/CoreBluetoothMock/CBMCentralManagerMock.swift
@@ -321,14 +321,21 @@ open class CBMCentralManagerMock: CBMCentralManager {
            let identifierKey = options[CBMCentralManagerOptionRestoreIdentifierKey] as? String,
            let dict = CBMCentralManagerMock.simulateStateRestoration?(identifierKey) {
             var state: [String : Any] = [:]
-            if let peripheralKeys = dict[CBMCentralManagerRestoredStatePeripheralsKey] {
-                state[CBMCentralManagerRestoredStatePeripheralsKey] = peripheralKeys
+            if let peripheralKeys = dict[CBMCentralManagerRestoredStatePeripheralsKey] as? [CBMPeripheralSpec] {
+                let peripherals = peripheralKeys.map { mock in
+                    CBMPeripheralMock(basedOn: mock, by: self, andRestoreState: true)
+                }
+                state[CBMCentralManagerRestoredStatePeripheralsKey] = peripherals
             }
-            if let scanServiceKey = dict[CBMCentralManagerRestoredStateScanServicesKey] {
+            if let scanServiceKey = dict[CBMCentralManagerRestoredStateScanServicesKey] as? [CBMUUID] {
                 state[CBMCentralManagerRestoredStateScanServicesKey] = scanServiceKey
+                self.isScanning = true
+                self.scanFilter = scanServiceKey
             }
-            if let scanOptions = dict[CBMCentralManagerRestoredStateScanOptionsKey] {
+            if let scanOptions = dict[CBMCentralManagerRestoredStateScanOptionsKey] as? [String : Any] {
                 state[CBMCentralManagerRestoredStateScanOptionsKey] = scanOptions
+                self.isScanning = true
+                self.scanOptions = scanOptions
             }
             delegate?.centralManager(self, willRestoreState: state)
         }
@@ -932,13 +939,47 @@ open class CBMCentralManagerMock: CBMCentralManager {
     
     // MARK: Initializers
     
+    /// Creates a new peripheral mock based on the given peripheral specification.
+    ///
+    /// If the `restore` parameter is set to `false`, the peripheral will be in the
+    /// disconnected state even if the emulated device was connected. Central manager
+    /// needs to connect to the device to change the state.
+    ///
+    /// The `restore` parameter allows to restore the state of the peripheral, if the
+    /// application was terminated and the central manager was created with
+    /// `CBMCentralManagerOptionRestoreIdentifierKey` option.
+    /// If the same central manager (with the same identifier) had that device connected
+    /// or connecting when the app was terminated, the peripheral will be restored to the
+    /// same state.
+    ///
+    /// - Parameters:
+    ///   - mock: The peripheral specification.
+    ///   - manager: The mock central manager.
+    ///   - restore: `true` to restore the state of the peripheral, default is `false`.
     fileprivate init(basedOn mock: CBMPeripheralSpec,
-                     by manager: CBMCentralManagerMock) {
+                     by manager: CBMCentralManagerMock,
+                     andRestoreState restore: Bool = false) {
         self.mock = mock
         self.manager = manager
         self.availableWriteWithoutResponseBuffer = bufferSize
+        
+        // If the Central Manager restores its state, the previously
+        // connected peripherals may still be connected or connecting.
+        //
+        // If CBMPeripheralSpec was created using .connected(...), the
+        // virtual connections count has been set to 1.
+        // Then, it is up to the proximity to decide if the device is
+        // connected or connecting.
+        if restore && mock.isConnected {
+            self.state = mock.proximity != .outOfRange ? .connected : .connecting
+            self._canSendWriteWithoutResponse = state == .connected
+        }
     }
     
+    /// Creates a copy of the given peripheral mock.
+    ///
+    /// This new peripheral will be in disconnected state, even if the original
+    /// was connected.
     fileprivate init(copy: CBMPeripheralMock,
                      by manager: CBMCentralManagerMock) {
         self.mock = copy.mock
@@ -1579,6 +1620,18 @@ open class CBMCentralManagerMock: CBMCentralManager {
     
     open override var hash: Int {
         return mock.identifier.hashValue
+    }
+    
+    open override var debugDescription: String {
+        var stateString: String
+        switch state {
+        case .disconnected:  stateString = "disconnected"
+        case .connecting:    stateString = "connecting"
+        case .connected:     stateString = "connected"
+        case .disconnecting: stateString = "disconnecting"
+        @unknown default:    stateString = "unknown"
+        }
+        return "<CBMPeripheral: identifier: \(mock.identifier), mtu: \(mock.mtu ?? 23), state: \(stateString)>"
     }
 }
 

--- a/CoreBluetoothMock/CBMCentralManagerMock.swift
+++ b/CoreBluetoothMock/CBMCentralManagerMock.swift
@@ -971,8 +971,14 @@ open class CBMCentralManagerMock: CBMCentralManager {
         // virtual connections count has been set to 1.
         // Then, it is up to the proximity to decide if the device is
         // connected or connecting.
-        if restore && mock.isConnected {
-            self.state = mock.proximity != .outOfRange ? .connected : .connecting
+        if restore {
+            // A non-connectable device could not have been connected.
+            // Ignore it when restoring the state.
+            guard mock.services != nil else {
+                NSLog("Warning: The peripheral with identifier \(mock.identifier) is not connectable and can not be restored to connected state.")
+                return
+            }
+            self.state = mock.isConnected && mock.proximity != .outOfRange ? .connected : .connecting
             self._canSendWriteWithoutResponse = state == .connected
         }
     }

--- a/CoreBluetoothMock/CBMCentralManagerNative.swift
+++ b/CoreBluetoothMock/CBMCentralManagerNative.swift
@@ -617,4 +617,9 @@ public class CBMPeripheralNative: CBMPeer, CBMPeripheral {
     public override var hash: Int {
         return identifier.hashValue
     }
+    
+    public override var debugDescription: String {
+        return peripheral.debugDescription
+            .replacingOccurrences(of: "CBPeripheral", with: "CBMPeripheral")
+    }
 }

--- a/CoreBluetoothMock/CBMManagerTypes.swift
+++ b/CoreBluetoothMock/CBMManagerTypes.swift
@@ -140,7 +140,7 @@ public let CBMCentralManagerOptionShowPowerAlertKey = CBCentralManagerOptionShow
 public let CBMCentralManagerOptionRestoreIdentifierKey = CBCentralManagerOptionRestoreIdentifierKey
 /// An array of peripherals for use when restoring the state of a central manager.
 ///
-/// The value associated with this key is an `NSArray` of ``CBMPeripheral`` objects.
+/// The value associated with this key is an `NSArray` of ``CBMPeripheralSpec`` objects.
 /// The array contains all of the peripherals connected to the central manager
 /// (or had a pending connection) at the time the system terminated the app.
 ///

--- a/CoreBluetoothMock/CBMPeripheralSpec.swift
+++ b/CoreBluetoothMock/CBMPeripheralSpec.swift
@@ -514,7 +514,9 @@ public class CBMPeripheralSpec {
             self.connectionInterval = connectionInterval
             self.supervisionTimeout = supervisionTimeout
             self.mtu = max(23, min(517, mtu))
-            self.isInitiallyConnected = proximity != .outOfRange
+            // The initial state will be .connected if proximity != .outOfRange.
+            // or .connecting otherwise.
+            self.isInitiallyConnected = true
             self.isKnown = true
             return self
         }

--- a/Example/nRFBlinky/CoreBluetoothTypeAliases.swift
+++ b/Example/nRFBlinky/CoreBluetoothTypeAliases.swift
@@ -91,7 +91,7 @@ let CBCentralManagerOptionShowPowerAlertKey            = CBMCentralManagerOption
 let CBCentralManagerOptionRestoreIdentifierKey         = CBMCentralManagerOptionRestoreIdentifierKey
 /// An array of peripherals for use when restoring the state of a central manager.
 ///
-/// The value associated with this key is an `NSArray` of ``CBPeripheral`` objects.
+/// The value associated with this key is an `NSArray` of `CBMPeripheralSpec` objects.
 /// The array contains all of the peripherals connected to the central manager
 /// (or had a pending connection) at the time the system terminated the app.
 ///

--- a/Example/nRFBlinky/Info.plist
+++ b/Example/nRFBlinky/Info.plist
@@ -28,6 +28,10 @@
 	<string>nRF Blinky uses Bluetooth to communicate with the nRF Blinky sample application on nRF DK.</string>
 	<key>NSBluetoothPeripheralUsageDescription</key>
 	<string>nRF Blinky uses Bluetooth to communicate with the nRF Blinky sample application on the nRF DK.</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>bluetooth-central</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/Example/nRFBlinky/MockPeripherals.swift
+++ b/Example/nRFBlinky/MockPeripherals.swift
@@ -103,7 +103,7 @@ private class BlinkyCBMPeripheralSpecDelegate: CBMPeripheralSpecDelegate {
 }
 
 let blinky = CBMPeripheralSpec
-    .simulatePeripheral(proximity: .outOfRange)
+    .simulatePeripheral(proximity: .immediate)
     .advertising(
         advertisementData: [
             CBMAdvertisementDataLocalNameKey    : "nRF Blinky",
@@ -112,7 +112,7 @@ let blinky = CBMPeripheralSpec
         ],
         withInterval: 0.250,
         alsoWhenConnected: false)
-    .connectable(
+    .connected(
         name: "nRF Blinky",
         services: [.blinkyService],
         delegate: BlinkyCBMPeripheralSpecDelegate(),

--- a/Example/nRFBlinky/Models/BlinkyManager.swift
+++ b/Example/nRFBlinky/Models/BlinkyManager.swift
@@ -170,4 +170,8 @@ extension BlinkyManager: CBCentralManagerDelegate {
             blinky.post(.blinkyDidDisconnect(blinky, error: error))
         }
     }
+    
+    func centralManager(_ central: CBCentralManager, willRestoreState dict: [String : Any]) {
+        print("Restoring Central Manager state with \(dict)")
+    }
 }

--- a/Example/nRFBlinky/Models/BlinkyManager.swift
+++ b/Example/nRFBlinky/Models/BlinkyManager.swift
@@ -50,7 +50,10 @@ class BlinkyManager {
         centralManager = CBCentralManagerFactory.instance(
                 delegate: self,
                 queue: nil,
-                options: [CBCentralManagerOptionShowPowerAlertKey : true],
+                options: [
+                    CBCentralManagerOptionShowPowerAlertKey : true,
+                    CBCentralManagerOptionRestoreIdentifierKey : "no.nordicsemi.blinky"
+                ],
                 forceMock: mock
         )
     }
@@ -62,7 +65,9 @@ class BlinkyManager {
         if !centralManager.isScanning {
             centralManager.scanForPeripherals(
                     withServices: [BlinkyPeripheral.nordicBlinkyServiceUUID],
-                    options: [CBCentralManagerScanOptionAllowDuplicatesKey : true]
+                    options: [
+                        CBCentralManagerScanOptionAllowDuplicatesKey : true,
+                    ]
             )
         }
         return true


### PR DESCRIPTION
This PR fixes the Central Manager state restoration for mock central manager.

I acually tried starte restoration using a native API and did my best to repliacte the same behavior using mock implementation.

### Changes
* State restoration requires the app to have "Background Mode": `bluetooth-central` - this was added to nRF Blinky sample app.
* The Central Manager in nRF Blinku is created using an [identifier](https://developer.apple.com/documentation/corebluetooth/cbcentralmanageroptionrestoreidentifierkey):
   https://github.com/NordicSemiconductor/IOS-CoreBluetooth-Mock/blob/299124535078ad0ad441c0ccb48b4b4bb12ea4ae/Example/nRFBlinky/Models/BlinkyManager.swift#L50-L58
* This will cause the `CBCentralManagerDelegate` report [centralManager(_:willRestoreState:)](https://developer.apple.com/documentation/corebluetooth/cbcentralmanagerdelegate/centralmanager(_:willrestorestate:)) just after it has been initiated, before its state changes to `.poweredOn`.
* The reported restored state consists of 3 items:
   * Previously connected peripherals (as an array of `CBMPeripheral` in this library)
   * Previously used llist of Service UUID filters, when the app was killed during scanning and filter was set
   * Previously used scan options, when the app was killed during scanning and any option was set
* To mock this behavior the `CBMCentralManagerMock` has a static property `simulateStateRestoration`. An example, how it can be used is in `AppDelegate`:
   https://github.com/NordicSemiconductor/IOS-CoreBluetooth-Mock/blob/299124535078ad0ad441c0ccb48b4b4bb12ea4ae/Example/nRFBlinky/AppDelegate.swift#L67-L82
   Note, that the `CBMCentralManagerRestoredStatePeripheralsKey` key allows to set `CBMPeripheralSpec` to be returned to the delegate.
* The returned `CBMPeripheral` will be in stae `.connected`, or `.connecting`, depending on whether the device is in range, or not. Non-connectable peripheral specs are ignored.