### PR TITLE
New feature: Auto Reconnect (iOS 17+)

### DIFF
--- a/CoreBluetoothMock/CBMCentralManagerDelegate.swift
+++ b/CoreBluetoothMock/CBMCentralManagerDelegate.swift
@@ -118,10 +118,36 @@ public protocol CBMCentralManagerDelegate: AnyObject {
     /// - Parameters:
     ///   - central: The central manager providing this information.
     ///   - peripheral: The ``CBMPeripheral`` that has disconnected.
-    ///   - error: If an error occurred, the cause of the failure.
+    ///   - error: If an error occurred, the cause of the failure.∂
     func centralManager(_ central: CBMCentralManager,
                         didDisconnectPeripheral peripheral: CBMPeripheral,
                         error: Error?)
+    
+    /// This method is invoked upon the disconnection of a peripheral that was
+    /// connected by ``CBMCentralManager/connect(_:options:)``.
+    ///
+    /// If peripheral is connected with option
+    /// ``CBMConnectPeripheralOptionEnableAutoReconnect``,
+    /// the system will automatically invoke connect to the peripheral and if connection
+    /// is established with the peripheral afterwards,
+    /// ``CBMCentralManagerDelegate/centralManager(_:didConnect:)-p052``
+    /// can be invoked.
+    ///
+    /// If peripheral is connected without option
+    /// ``CBMConnectPeripheralOptionEnableAutoReconnect``, once this
+    /// method has been called, no more methods will be invoked peripheral's
+    /// ``CBMPeripheralDelegate``.
+    /// - Parameters:
+    ///   - central: The central manager providing this information.
+    ///   - peripheral: The ``CBMPeripheral`` that has disconnected.
+    ///   - timestamp: Timestamp of the disconnection, it can be now or a few seconds ago.
+    ///   - isReconnecting: If reconnect was triggered upon disconnection.
+    ///   - error: If an error occurred, the cause of the failure.
+    func centralManager(_ central: CBMCentralManager,
+                        didDisconnectPeripheral peripheral: CBMPeripheral,
+                        timestamp: CFAbsoluteTime,
+                        isReconnecting: Bool,
+                        error: (any Error)?)
     
     /// This method is invoked upon the connection or disconnection of a
     /// peripheral that matches any of the options provided in
@@ -177,6 +203,18 @@ public extension CBMCentralManagerDelegate {
                         didDisconnectPeripheral peripheral: CBMPeripheral,
                         error: Error?) {
         // optional method
+    }
+    
+    func centralManager(_ central: CBMCentralManager,
+                        didDisconnectPeripheral peripheral: CBMPeripheral,
+                        timestamp: CFAbsoluteTime,
+                        isReconnecting: Bool,
+                        error: (any Error)?) {
+        // If not implemented, call the standard
+        // centralManager(_, didDisconnectPeripheral:, error:) method.
+        centralManager(central,
+                       didDisconnectPeripheral: peripheral,
+                       error: error)
     }
     
     @available(iOS 13.0, *)

--- a/CoreBluetoothMock/CBMCentralManagerDelegateProxy.swift
+++ b/CoreBluetoothMock/CBMCentralManagerDelegateProxy.swift
@@ -39,7 +39,7 @@ open class CBMCentralManagerDelegateProxy: NSObject, CBMCentralManagerDelegate {
     public var didDiscoverPeripheral: ((CBMCentralManager, CBMPeripheral, [String : Any], NSNumber) -> ())?
     public var didConnect: ((CBMCentralManager, CBMPeripheral) -> ())?
     public var didFailToConnect: ((CBMCentralManager, CBMPeripheral, Error?) -> ())?
-    public var didDisconnect: ((CBMCentralManager, CBMPeripheral, Error?) -> ())?
+    public var didDisconnect: ((CBMCentralManager, CBMPeripheral, CFAbsoluteTime, Bool, Error?) -> ())?
     public var connectionEventDidOccur: ((CBMCentralManager, CBMConnectionEvent, CBMPeripheral) -> ())?
     public var didUpdateANCSAuthorization: ((CBMCentralManager, CBMPeripheral) -> ())?
     
@@ -73,7 +73,15 @@ open class CBMCentralManagerDelegateProxy: NSObject, CBMCentralManagerDelegate {
     open func centralManager(_ central: CBMCentralManager,
                                didDisconnectPeripheral peripheral: CBMPeripheral,
                                error: Error?) {
-        didDisconnect?(central, peripheral, error)
+        didDisconnect?(central, peripheral, CFAbsoluteTimeGetCurrent(), false, error)
+    }
+    
+    open func centralManager(_ central: CBMCentralManager,
+                               didDisconnectPeripheral peripheral: CBMPeripheral,
+                               timestamp: CFAbsoluteTime,
+                               isReconnecting: Bool,
+                               error: (any Error)?) {
+        didDisconnect?(central, peripheral, timestamp, isReconnecting, error)
     }
     
     @available(iOS 13.0, *)

--- a/CoreBluetoothMock/CBMCentralManagerMock.swift
+++ b/CoreBluetoothMock/CBMCentralManagerMock.swift
@@ -470,33 +470,6 @@ open class CBMCentralManagerMock: CBMCentralManager {
     
     // MARK: - Peripheral simulation methods
     
-    /// Simulates a situation when the given peripheral was moved closer
-    /// or away from the phone.
-    ///
-    /// If the proximity is changed to ``CBMProximity/outOfRange``, the peripheral will
-    /// be disconnected and will not appear on scan results.
-    /// - Parameter peripheral: The peripheral that was repositioned.
-    /// - Parameter proximity: The new peripheral proximity.
-    internal static func proximity(of peripheral: CBMPeripheralSpec,
-                                   didChangeTo proximity: CBMProximity) {
-        guard peripheral.proximity != proximity else {
-            return
-        }
-        // Is the peripheral simulated?
-        guard peripherals.contains(peripheral) else {
-            return
-        }
-        peripheral.proximity = proximity
-        
-        if proximity == .outOfRange {
-            self.peripheral(peripheral,
-                            didDisconnectWithError: CBMError(.connectionTimeout))
-        } // else {
-            // If a device got in range an advertising packet will be received
-            // at some point. Any pending connections will succeed at that time.
-        //}
-    }
-    
     /// Simulates a situation when the device changes its services.
     /// - Parameters:
     ///   - peripheral: The peripheral that changed services.
@@ -632,17 +605,10 @@ open class CBMCentralManagerMock: CBMCentralManager {
     ///   - error: The disconnection reason. Use ``CBMError`` or ``CBMATTError`` errors.
     internal static func peripheral(_ peripheral: CBMPeripheralSpec,
                                     didDisconnectWithError error: Error = CBError(.peripheralDisconnected)) {
-        // Is the device connected at all?
-        guard peripheral.isConnected else {
-            return
-        }
         // Is the peripheral simulated?
         guard peripherals.contains(peripheral) else {
             return
         }
-        // The device has disconnected, so it can start advertising
-        // immediately.
-        peripheral.virtualConnections = 0
         // Notify all central managers.
         let existingManagers = CBMCentralManagerMock.mutex.sync {
             managers.compactMap { $0.ref }
@@ -653,6 +619,8 @@ open class CBMCentralManagerMock: CBMCentralManager {
                 target.disconnected(withError: error) { error in
                     manager.delegate?.centralManager(manager,
                                                      didDisconnectPeripheral: target,
+                                                     timestamp: CFAbsoluteTimeGetCurrent(),
+                                                     isReconnecting: target.isReconnecting,
                                                      error: error)
                 }
             }
@@ -725,8 +693,16 @@ open class CBMCentralManagerMock: CBMCentralManager {
         }
         // Central manager must be in powered on state.
         guard ensurePoweredOn() else { return }
-        if let o = options, !o.isEmpty {
-            NSLog("Warning: Connection options are not supported in mock central manager")
+        // Read connection options. Currently only auto-reconnect is supported.
+        var enableAutoReconnect = false
+        if var o = options {
+            if #available(iOS 17.0, *) {
+                let option = o.removeValue(forKey: CBMConnectPeripheralOptionEnableAutoReconnect) as? NSNumber
+                enableAutoReconnect = option?.boolValue ?? false
+            }
+            if !o.isEmpty {
+                NSLog("Warning: Connection options are not supported in mock central manager")
+            }
         }
         // Ignore peripherals that are not mocks.
         guard let mock = peripheral as? CBMPeripheralMock else {
@@ -741,6 +717,7 @@ open class CBMCentralManagerMock: CBMCentralManager {
         }
         // Connection is pending.
         mock.state = .connecting
+        mock.isReconnecting = enableAutoReconnect
         // If the device is already connected, there is no need to waiting for
         // advertising packet.
         if mock.isAlreadyConnected {
@@ -754,7 +731,11 @@ open class CBMCentralManagerMock: CBMCentralManager {
         // Handle the Preview peripheral.
         if let peripheral = peripheral as? CBMPeripheralPreview {
             peripheral.state = .disconnected
-            delegate?.centralManager(self, didDisconnectPeripheral: peripheral, error: nil)
+            delegate?.centralManager(self,
+                                     didDisconnectPeripheral: peripheral,
+                                     timestamp: CFAbsoluteTimeGetCurrent(),
+                                     isReconnecting: false,
+                                     error: nil)
             return
         }
         // Central manager must be in powered on state.
@@ -769,7 +750,10 @@ open class CBMCentralManagerMock: CBMCentralManager {
             return
         }
         mock.disconnect() {
-            self.delegate?.centralManager(self, didDisconnectPeripheral: mock,
+            self.delegate?.centralManager(self,
+                                          didDisconnectPeripheral: mock,
+                                          timestamp: CFAbsoluteTimeGetCurrent(),
+                                          isReconnecting: false,
                                           error: nil)
         }
     }
@@ -913,6 +897,12 @@ open class CBMCentralManagerMock: CBMCentralManager {
     /// The current buffer size.
     private var availableWriteWithoutResponseBuffer: Int
     private var _canSendWriteWithoutResponse: Bool = false
+    /// A flag indicating whether the last connection attempt was
+    /// using ``CBMConnectPeripheralOptionEnableAutoReconnect`` option.
+    ///
+    /// This flag is only cleared when the device is disconnected using
+    /// ``CBMCentralManager/cancelPeripheralConnection(_:)``.
+    fileprivate var isReconnecting: Bool = false
     
     /// A flag set to `true` when the device was scanned for the first time during
     /// a single scan. This is to ensure that the result is not delivered twice unless
@@ -964,6 +954,7 @@ open class CBMCentralManagerMock: CBMCentralManager {
         self.mock = mock
         self.manager = manager
         self.availableWriteWithoutResponseBuffer = bufferSize
+        self.isReconnecting = restore
         
         // If the Central Manager restores its state, the previously
         // connected peripherals may still be connected or connecting.
@@ -1043,6 +1034,8 @@ open class CBMCentralManagerMock: CBMCentralManager {
     }
     
     fileprivate func disconnect(completion: @escaping () -> ()) {
+        // Cancel auto-reconnection.
+        isReconnecting = false
         // Cancel pending connection.
         guard state != .connecting else {
             state = .disconnected
@@ -1068,8 +1061,12 @@ open class CBMCentralManagerMock: CBMCentralManager {
                 self.services = nil
                 self._canSendWriteWithoutResponse = false
                 self.mock.virtualConnections -= 1
-                self.mock.connectionDelegate?.peripheral(self.mock,
-                                                         didDisconnect: nil)
+                // Notify the mock delegate when the last connection
+                // was terminated.
+                if mock.virtualConnections == 0 {
+                    self.mock.connectionDelegate?.peripheral(self.mock,
+                                                             didDisconnect: nil)
+                }
                 completion()
             }
         }
@@ -1091,15 +1088,13 @@ open class CBMCentralManagerMock: CBMCentralManager {
         }
         queue.asyncAfter(deadline: .now() + interval) { [weak self] in
             if let self = self, CBMCentralManagerMock.managerState == .poweredOn {
-                self.state = .disconnected
-                self.services = nil
+                if isReconnecting {
+                    self.state = .connecting
+                } else {
+                    self.state = .disconnected
+                    self.services = nil
+                }
                 self._canSendWriteWithoutResponse = false
-                // If the disconnection happen without an error, the device
-                // must have been disconnected disconnected from central
-                // manager.
-                self.mock.virtualConnections = 0
-                self.mock.connectionDelegate?.peripheral(self.mock,
-                                                         didDisconnect: error)
                 completion(error)
             }
         }
@@ -1297,9 +1292,13 @@ open class CBMCentralManagerMock: CBMCentralManager {
                     // Filter all service characteristics that match given list (if set).
                     .filter { characteristicUUIDs == nil || characteristicUUIDs!.isEmpty || characteristicUUIDs!.contains($0.uuid) }
                     // Filter those of them, that are not already in discovered characteristics.
-                    .filter { c in !service._characteristics!
-                        .contains { dc in c.identifier == dc.identifier }
-                    }
+                    // NOTE FOR THE CODE COMMENTED OUT
+                    // Seems like second discovery resets the state of a characteristic,
+                    // including isNotifying and inner descriptors.
+                    // TODO: The last part should be tested.
+//                    .filter { c in !service._characteristics!
+//                        .contains { dc in c.identifier == dc.identifier }
+//                    }
                     // Copy the characteristic info, without included descriptors or value.
                     .map { CBMCharacteristic(shallowCopy: $0, in: service) }
             let newCharacteristicsCount = service._characteristics!.count - initialSize

--- a/CoreBluetoothMock/CBMCentralManagerMock.swift
+++ b/CoreBluetoothMock/CBMCentralManagerMock.swift
@@ -326,6 +326,9 @@ open class CBMCentralManagerMock: CBMCentralManager {
                     CBMPeripheralMock(basedOn: mock, by: self, andRestoreState: true)
                 }
                 state[CBMCentralManagerRestoredStatePeripheralsKey] = peripherals
+                peripherals.forEach { peripheral in
+                    self.peripherals[peripheral.identifier] = peripheral
+                }
             }
             if let scanServiceKey = dict[CBMCentralManagerRestoredStateScanServicesKey] as? [CBMUUID] {
                 state[CBMCentralManagerRestoredStateScanServicesKey] = scanServiceKey

--- a/CoreBluetoothMock/CBMCentralManagerNative.swift
+++ b/CoreBluetoothMock/CBMCentralManagerNative.swift
@@ -213,8 +213,10 @@ public class CBMCentralManagerNative: CBMCentralManager {
             var state = dict
             
             if let peripherals = dict[CBCentralManagerRestoredStatePeripheralsKey] as? [CBPeripheral] {
-                state[CBMCentralManagerRestoredStatePeripheralsKey] = peripherals.map {
-                    CBMPeripheralNative($0)
+                let nativePeripherals = peripherals.map { CBMPeripheralNative($0) }
+                state[CBMCentralManagerRestoredStatePeripheralsKey] = nativePeripherals
+                nativePeripherals.forEach { peripheral in
+                    manager.peripherals[peripheral.identifier] = peripheral
                 }
             }
                         

--- a/CoreBluetoothMock/CBMManagerTypes.swift
+++ b/CoreBluetoothMock/CBMManagerTypes.swift
@@ -255,3 +255,11 @@ public let CBMConnectPeripheralOptionNotifyOnNotificationKey = CBConnectPeripher
 @available(iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 public let CBMConnectPeripheralOptionEnableTransportBridgingKey = CBConnectPeripheralOptionEnableTransportBridgingKey
 #endif
+/// An Boolean indicating that the AutoReconnect is enabled for the peripheral is connected.
+///
+/// After peripheral device is connected, this will allow the system to initiate connect to the peer
+/// device automatically when link is dropped.
+///
+/// Caller will get notified about the disconnection with potential delay via {@link centralManager:didDisconnectPeripheral:timestamp:isReconnecting:error:}
+@available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+public let CBMConnectPeripheralOptionEnableAutoReconnect = CBConnectPeripheralOptionEnableAutoReconnect

--- a/Example/Tests/FailedConnectionTest.swift
+++ b/Example/Tests/FailedConnectionTest.swift
@@ -92,11 +92,12 @@ class FailedConnectionTest: XCTestCase {
         // As the device is now out of range, connection should fail.
         let connected = XCTestExpectation(description: "Connected")
         connected.isInverted = true
-        target!.onConnected {
+        let connectionObserver = target!.onConnected {
             connected.fulfill() // This should not happen.
         }
         // As the expectation is inverted, the wait should timeout.
         wait(for: [connected], timeout: 3)
+        Sim.dispose(connectionObserver)
 
         let appDelegate = UIApplication.shared.delegate as! AppDelegate
         let navigationController = appDelegate.window!.rootViewController as! UINavigationController

--- a/Example/Tests/FailedConnectionTest.swift
+++ b/Example/Tests/FailedConnectionTest.swift
@@ -87,7 +87,7 @@ class FailedConnectionTest: XCTestCase {
         blinky.simulateProximityChange(.outOfRange)
         
         // Select found device.
-        Sim.post(.selectPeripheral(at: 0))
+        Sim.post(.selectPeripheral(target!))
 
         // As the device is now out of range, connection should fail.
         let connected = XCTestExpectation(description: "Connected")

--- a/Example/Tests/NormalBehaviorTest.swift
+++ b/Example/Tests/NormalBehaviorTest.swift
@@ -83,7 +83,7 @@ class NormalBehaviorTest: XCTestCase {
         }
         
         // Select found device.
-        Sim.post(.selectPeripheral(at: 0))
+        Sim.post(.selectPeripheral(target!))
 
         // Wait until blinky is connected and ready.
         let connected = XCTestExpectation(description: "Connected")

--- a/Example/Tests/NormalBehaviorTest.swift
+++ b/Example/Tests/NormalBehaviorTest.swift
@@ -88,15 +88,17 @@ class NormalBehaviorTest: XCTestCase {
         // Wait until blinky is connected and ready.
         let connected = XCTestExpectation(description: "Connected")
         let ready = XCTestExpectation(description: "Ready")
-        target!.onConnected {
+        let connectionObserver = target!.onConnected {
             connected.fulfill()
         }
-        target!.onReady { ledSupported, buttonSupported in
+        let readyObserver = target!.onReady { ledSupported, buttonSupported in
             if ledSupported && buttonSupported {
                 ready.fulfill()
             }
         }
         wait(for: [connected, ready], timeout: 3)
+        Sim.dispose(connectionObserver)
+        Sim.dispose(readyObserver)
 
         let appDelegate = UIApplication.shared.delegate as! AppDelegate
         let navigationController = appDelegate.window!.rootViewController as! UINavigationController
@@ -138,12 +140,13 @@ class NormalBehaviorTest: XCTestCase {
 
         // Simulate graceful disconnect.
         let disconnection = XCTestExpectation(description: "Disconnection")
-        target!.onDisconnected { error in
+        let disconnectionObserver = target!.onDisconnected { error in
             XCTAssertEqual((error as? CBMError)?.code, CBError.peripheralDisconnected)
             disconnection.fulfill()
         }
         blinky.simulateDisconnection()
         wait(for: [disconnection], timeout: 1)
+        Sim.dispose(disconnectionObserver)
 
         navigationController.popViewController(animated: true)
     }

--- a/Example/Tests/ResetTest.swift
+++ b/Example/Tests/ResetTest.swift
@@ -88,15 +88,17 @@ class ResetTest: XCTestCase {
         // Wait until blinky is connected and ready.
         let connected = XCTestExpectation(description: "Connected")
         let ready = XCTestExpectation(description: "Ready")
-        target!.onConnected {
+        let o1 = target!.onConnected {
             connected.fulfill()
         }
-        target!.onReady { ledSupported, buttonSupported in
+        let o2 = target!.onReady { ledSupported, buttonSupported in
             if ledSupported && buttonSupported {
                 ready.fulfill()
             }
         }
         wait(for: [connected, ready], timeout: 3)
+        target!.dispose(o1)
+        target!.dispose(o2)
 
         let appDelegate = UIApplication.shared.delegate as! AppDelegate
         let navigationController = appDelegate.window!.rootViewController as! UINavigationController
@@ -123,13 +125,14 @@ class ResetTest: XCTestCase {
 
         // Simulate reset and button press afterwards.
         let reset = XCTestExpectation(description: "Reset")
-        target!.onDisconnected { error in
+        let disconnectionObserver = target!.onDisconnected { error in
             XCTAssertEqual((error as? CBMError)?.code, CBError.connectionTimeout)
             reset.fulfill()
         }
         blinky.simulateReset()
         blinky.simulateValueUpdate(Data([0x01]), for: .buttonCharacteristic)
         wait(for: [reset, buttonPressed], timeout: 5)
+        Sim.dispose(disconnectionObserver)
 
         Sim.dispose(ledObserver)
         Sim.dispose(buttonObserver)

--- a/Example/Tests/ResetTest.swift
+++ b/Example/Tests/ResetTest.swift
@@ -83,7 +83,7 @@ class ResetTest: XCTestCase {
         }
 
         // Select found device.
-        Sim.post(.selectPeripheral(at: 0))
+        Sim.post(.selectPeripheral(target!))
 
         // Wait until blinky is connected and ready.
         let connected = XCTestExpectation(description: "Connected")

--- a/Example/nRFBlinky/AppDelegate.swift
+++ b/Example/nRFBlinky/AppDelegate.swift
@@ -69,12 +69,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 if identifierKey == "no.nordicsemi.blinky" {
                     return [
                         // When the app was killed it was scanning with the LBS Service UUID filter.
-                        CBMCentralManagerRestoredStateScanServicesKey: [CBMUUID.nordicBlinkyService],
+                        CBMCentralManagerRestoredStateScanServicesKey: [
+                            CBMUUID.nordicBlinkyService
+                        ],
                         // Also, the app was scanning with the "Allow Duplicates" option enabled.
-                        CBMCentralManagerRestoredStateScanOptionsKey: [CBMCentralManagerScanOptionAllowDuplicatesKey: true as NSNumber],
-                        // nRF Blinky was already connected. Check out, that the
-                        // blinky spec was created using .connected(...) and it is
-                        // in range.
+                        CBMCentralManagerRestoredStateScanOptionsKey: [
+                            CBMCentralManagerScanOptionAllowDuplicatesKey: true as NSNumber
+                        ],
+                        // Here we may simulate peripheral state restoration.
+                        // Depending on whether the peripheral spec was created using
+                        // .connectable(...) or .connected(...), and the proximity value
+                        // the peripheral will be restored with state .connecting or .connected.
+                        //
                         CBMCentralManagerRestoredStatePeripheralsKey: [blinky]
                     ]
                 }
@@ -86,8 +92,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             hrm.simulateProximityChange(.near)
             thingy.simulateProximityChange(.far)
             
-            // Simulate a reset after 500 ms to make the device discoverable again:
-            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(500)) {
+            // Simulate a reset after a while to make the device reconnect again:
+            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(3000)) {
                 blinky.simulateReset()
             }
         }

--- a/Example/nRFBlinky/CoreBluetoothTypeAliases.swift
+++ b/Example/nRFBlinky/CoreBluetoothTypeAliases.swift
@@ -197,3 +197,13 @@ let CBConnectPeripheralOptionNotifyOnDisconnectionKey  = CBMConnectPeripheralOpt
 /// most recently in the foreground receives the alert. If the key isn’t specified, the default
 /// value is `false`.
 let CBConnectPeripheralOptionNotifyOnNotificationKey   = CBMConnectPeripheralOptionNotifyOnNotificationKey
+/// An Boolean indicating that the AutoReconnect is enabled for the peripheral is connected.
+///
+/// After peripheral device is connected, this will allow the system to initiate connect to the peer
+/// device automatically when link is dropped.
+///
+/// Caller will get notified about the disconnection with potential delay via
+/// ``CBCentralManagerDelegate/centralManager(_:didConnect:)`` method
+/// `centralManager(:didDisconnectPeripheral:timestamp:isReconnecting:error:)`
+@available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *)
+let CBConnectPeripheralOptionEnableAutoReconnect       = CBMConnectPeripheralOptionEnableAutoReconnect

--- a/Example/nRFBlinky/MockPeripherals.swift
+++ b/Example/nRFBlinky/MockPeripherals.swift
@@ -108,6 +108,10 @@ private class BlinkyCBMPeripheralSpecDelegate: CBMPeripheralSpecDelegate {
         }
         return .success(())
     }
+    
+    func peripheral(_ peripheral: CBMPeripheralSpec, didDisconnect error: (any Error)?) {
+        print("Central disconnected with error: \(error?.localizedDescription ?? "none")")
+    }
 }
 
 let blinky = CBMPeripheralSpec

--- a/Example/nRFBlinky/MockPeripherals.swift
+++ b/Example/nRFBlinky/MockPeripherals.swift
@@ -124,11 +124,12 @@ let blinky = CBMPeripheralSpec
         ],
         withInterval: 0.250,
         alsoWhenConnected: false)
-    .connected(
+    .connectable(
         name: "nRF Blinky",
         services: [.blinkyService],
         delegate: BlinkyCBMPeripheralSpecDelegate(),
         connectionInterval: 0.150,
+        supervisionTimeout: 0,
         mtu: 23)
     .build()
 

--- a/Example/nRFBlinky/Models/BlinkyManager.swift
+++ b/Example/nRFBlinky/Models/BlinkyManager.swift
@@ -198,12 +198,13 @@ extension BlinkyManager: CBCentralManagerDelegate {
     public func centralManager(_ central: CBCentralManager,
                                didDisconnectPeripheral peripheral: CBPeripheral,
                                error: Error?) {
-        if let blinky = connectedBlinky,
-           blinky.basePeripheral.identifier == peripheral.identifier {
-            print("Blinky disconnected")
-            connectedBlinky = nil
-            blinky.post(.blinkyDidDisconnect(blinky, error: error))
-        }
+        assertionFailure("This method should not be called when the next one is implemented.")
+        // if let blinky = connectedBlinky,
+        //    blinky.basePeripheral.identifier == peripheral.identifier {
+        //     print("Blinky disconnected")
+        //     connectedBlinky = nil
+        //     blinky.post(.blinkyDidDisconnect(blinky, error: error))
+        // }
     }
     
     func centralManager(_ central: CBCentralManager,

--- a/Example/nRFBlinky/Models/BlinkyManagerEvents.swift
+++ b/Example/nRFBlinky/Models/BlinkyManagerEvents.swift
@@ -34,6 +34,7 @@ import CoreBluetoothMock
 extension Notification.Name {
 
     static let newPeripheral = Notification.Name("New Peripheral")
+    static let newConnection = Notification.Name("New Connection")
     static let state         = Notification.Name("Central Manager State")
 
 }
@@ -42,6 +43,12 @@ extension Notification {
 
     static func manager(_ manager: BlinkyManager, didDiscover blinky: BlinkyPeripheral) -> Notification {
         return Notification(name: .newPeripheral,
+                            object: manager,
+                            userInfo: ["blinky": blinky])
+    }
+    
+    static func manager(_ manager: BlinkyManager, didConnect blinky: BlinkyPeripheral) -> Notification {
+        return Notification(name: .newConnection,
                             object: manager,
                             userInfo: ["blinky": blinky])
     }
@@ -70,6 +77,15 @@ extension BlinkyManager {
 
     func onBlinkyDiscovery(do action: @escaping (BlinkyPeripheral) -> ()) -> NSObjectProtocol {
         return on(.newPeripheral) { notification in
+            if let userInfo = notification.userInfo,
+               let blinky = userInfo["blinky"] as? BlinkyPeripheral {
+                action(blinky)
+            }
+        }
+    }
+    
+    func onBlinkyConnected(do action: @escaping (BlinkyPeripheral) -> ()) -> NSObjectProtocol {
+        return on(.newConnection) { notification in
             if let userInfo = notification.userInfo,
                let blinky = userInfo["blinky"] as? BlinkyPeripheral {
                 action(blinky)

--- a/Example/nRFBlinky/ViewControllers/ScannerView/ScannerTableViewController.swift
+++ b/Example/nRFBlinky/ViewControllers/ScannerView/ScannerTableViewController.swift
@@ -61,6 +61,10 @@ class ScannerTableViewController: UITableViewController {
         _ = manager.onBlinkyDiscovery { [unowned self] blinky in
             self.addOrUpdateBlinky(blinky)
         }
+        _ = manager.onBlinkyConnected { [unowned self] blinky in
+            self.stopScan()
+            self.connectBlinky(blinky)
+        }
         _ = onPeripheralSelected { [unowned self] blinky in
             self.stopScan()
             self.connectBlinky(blinky)

--- a/Example/nRFBlinky/ViewControllers/ScannerView/ScannerTableViewController.swift
+++ b/Example/nRFBlinky/ViewControllers/ScannerView/ScannerTableViewController.swift
@@ -60,6 +60,7 @@ class ScannerTableViewController: UITableViewController {
         }
         _ = manager.onBlinkyDiscovery { [unowned self] blinky in
             self.addOrUpdateBlinky(blinky)
+            self.hideEmptyPeripheralsView()
         }
         _ = manager.onBlinkyConnected { [unowned self] blinky in
             self.stopScan()
@@ -74,6 +75,7 @@ class ScannerTableViewController: UITableViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         manager.reset()
+        showEmptyPeripheralsView()
         tableView.reloadData()
     }
     
@@ -110,11 +112,6 @@ class ScannerTableViewController: UITableViewController {
     // MARK: - UITableViewDelegate
     
     override func numberOfSections(in tableView: UITableView) -> Int {
-        if manager.isEmpty {
-            showEmptyPeripheralsView()
-        } else {
-            hideEmptyPeripheralsView()
-        }
         return manager.discoveredPeripherals.count > 0 ? 1 : 0
     }
     


### PR DESCRIPTION
This PR adds support for Auto Reconnect feature, added in iOS 17 with [CBConnectPeripheralOptionEnableAutoReconnect](https://developer.apple.com/documentation/corebluetooth/cbconnectperipheraloptionenableautoreconnect).

### Initialization
Connection with Auto Reconnection enabled is initiated with this flag:
https://github.com/NordicSemiconductor/IOS-CoreBluetooth-Mock/blob/78a577ec9889e0f043c5dda2ee8b4a46674e1158/Example/nRFBlinky/Models/BlinkyManager.swift#L98-L105

It's supported on iOS 17 and newer.

Besides this flag, a new [delegate method](https://developer.apple.com/documentation/corebluetooth/cbcentralmanagerdelegate/centralmanager(_:diddisconnectperipheral:timestamp:isreconnecting:error:)) was added to iOS API:
```swift
optional func centralManager(
    _ central: CBCentralManager,
    didDisconnectPeripheral peripheral: CBPeripheral,
    timestamp: CFAbsoluteTime,
    isReconnecting: Bool,
    error: (any Error)?
)
```
This callback is ONLY CALLED when there the `centralManager(_:didDisconnectPeripheral:error)` is not implemented, and only on iOS 17+ (despite what the documentation says).

### CoreBluetooth Mock

This PR adds the flag and the above callback to the library. For mock devices, the automatic connection will happen on the first received connectable packet from a mock peripheral.

However, it was not possible to reproduce this (_unintended? undocumented? diffcult to use?_) behavior of NOT calling this delegate method when the previous `centralManager(_:didDisconnectPeripheral:error)` was implemented (the library has to implement it, but can't check if the user has implemented it using Swift).

Instead, this delegate method will be called from the library and the default implementation will call the old one. So, if the app implements only the old one, only the old one will be called, like before. If the new and old one is implemented, the old one will not be implemented. This is DIFFERENT from the native behavior, which calls only the new one in such case.
We recommend only using the new one, which in this library will be called also for iOS pre-17.