### PR TITLE
Deprecated methods removed

### DIFF
--- a/CoreBluetoothMock/CBMPeripheralSpec.swift
+++ b/CoreBluetoothMock/CBMPeripheralSpec.swift
@@ -154,31 +154,6 @@ public class CBMPeripheralSpec {
     /// - Since: 0.15.0
     public internal(set) var advertisement: [CBMAdvertisementConfig]?
     
-    /// The device's advertising data.
-    ///
-    /// This property was deprecated in version 0.15.0 with added support for multiple
-    /// advertisements per peripheral. Use ``CBMPeripheralSpec/advertisement`` instead.
-    @available(*, deprecated, message: "Use advertisement configurations instead")
-    public var advertisementData: [String : Any]? {
-        return advertisement?.first?.data
-    }
-    /// The advertising interval.
-    ///
-    /// This property was deprecated in version 0.15.0 with added support for multiple
-    /// advertisements per peripheral. Use ``CBMPeripheralSpec/advertisement`` instead.
-    @available(*, deprecated, message: "Use advertisement configurations instead")
-    public var advertisingInterval: TimeInterval? {
-        return advertisement?.first?.interval
-    }
-    /// Should the mock peripheral appear in scan results when it's connected.
-    ///
-    /// This property was deprecated in version 0.15.0 with added support for multiple
-    /// advertisements per peripheral. Use ``CBMPeripheralSpec/advertisement`` instead.
-    @available(*, deprecated, message: "Use advertisement configurations instead")
-    public var isAdvertisingWhenConnected: Bool {
-        return advertisement?.first?.isAdvertisingWhenConnected ?? false
-    }
-    
     /// List of services available for service discovery.
     public internal(set) var services: [CBMServiceMock]?
     /// The connection interval.

--- a/CoreBluetoothMock/CBMPeripheralSpecDelegate.swift
+++ b/CoreBluetoothMock/CBMPeripheralSpecDelegate.swift
@@ -78,12 +78,6 @@ public protocol CBMPeripheralSpecDelegate {
                     didReceiveIncludedServiceDiscoveryRequest serviceUUIDs: [CBMUUID]?,
                     for service: CBMServiceMock)
         -> Result<Void, Error>
-    
-    @available(*, deprecated, message: "Use similar method with CBMServiceMock parameter type.")
-    func peripheral(_ peripheral: CBMPeripheralSpec,
-                    didReceiveIncludedServiceDiscoveryRequest serviceUUIDs: [CBMUUID]?,
-                    for service: CBMService)
-        -> Result<Void, Error>
 
     /// This method will be called when characteristic discovery was initiated using a
     /// mock central manager. When success is returned, the characteristics will be returned
@@ -98,12 +92,6 @@ public protocol CBMPeripheralSpecDelegate {
                     didReceiveCharacteristicsDiscoveryRequest characteristicUUIDs: [CBMUUID]?,
                     for service: CBMServiceMock)
         -> Result<Void, Error>
-    
-    @available(*, deprecated, message: "Use similar method with CBMServiceMock parameter type.")
-    func peripheral(_ peripheral: CBMPeripheralSpec,
-                    didReceiveCharacteristicsDiscoveryRequest characteristicUUIDs: [CBMUUID]?,
-                    for service: CBMService)
-        -> Result<Void, Error>
 
     /// This method will be called when descriptor discovery was initiated using a
     /// mock central manager. When success is returned, the descriptors will be returned
@@ -116,12 +104,6 @@ public protocol CBMPeripheralSpecDelegate {
     func peripheral(_ peripheral: CBMPeripheralSpec,
                     didReceiveDescriptorsDiscoveryRequestFor characteristic: CBMCharacteristicMock)
         -> Result<Void, Error>
-    
-    @available(*, deprecated, message: "Use similar method with CBMCharacteristicMock parameter type.")
-    func peripheral(_ peripheral: CBMPeripheralSpec,
-                    didReceiveDescriptorsDiscoveryRequestFor characteristic: CBMCharacteristic)
-        -> Result<Void, Error>
-
     /// This method will be called when read request has been initiated from a mock
     /// central manager.
     /// - Parameters:
@@ -132,11 +114,6 @@ public protocol CBMPeripheralSpecDelegate {
     ///            ``CBMPeripheralDelegate/peripheral(_:didUpdateValueFor:error:)-2xce0``.
     func peripheral(_ peripheral: CBMPeripheralSpec,
                     didReceiveReadRequestFor characteristic: CBMCharacteristicMock)
-        -> Result<Data, Error>
-    
-    @available(*, deprecated, message: "Use similar method with CBMCharacteristicMock parameter type.")
-    func peripheral(_ peripheral: CBMPeripheralSpec,
-                    didReceiveReadRequestFor characteristic: CBMCharacteristic)
         -> Result<Data, Error>
 
     /// This method will be called when read request has been initiated from a mock
@@ -149,11 +126,6 @@ public protocol CBMPeripheralSpecDelegate {
     ///            ``CBMPeripheralDelegate/peripheral(_:didUpdateValueFor:error:)-2xce0``.
     func peripheral(_ peripheral: CBMPeripheralSpec,
                     didReceiveReadRequestFor descriptor: CBMDescriptorMock)
-        -> Result<Data, Error>
-    
-    @available(*, deprecated, message: "Use similar method with CBMDescriptorMock parameter type.")
-    func peripheral(_ peripheral: CBMPeripheralSpec,
-                    didReceiveReadRequestFor descriptor: CBMDescriptor)
         -> Result<Data, Error>
 
     /// This method will be called when write request has been initiated from a mock
@@ -168,12 +140,6 @@ public protocol CBMPeripheralSpecDelegate {
                     didReceiveWriteRequestFor characteristic: CBMCharacteristicMock,
                     data: Data)
         -> Result<Void, Error>
-    
-    @available(*, deprecated, message: "Use similar method with CBMCharacteristicMock parameter type.")
-    func peripheral(_ peripheral: CBMPeripheralSpec,
-                    didReceiveWriteRequestFor characteristic: CBMCharacteristic,
-                    data: Data)
-        -> Result<Void, Error>
 
     /// This method will be called when write command has been initiated from a mock
     /// central manager. Write command is also known as write without response.
@@ -183,11 +149,6 @@ public protocol CBMPeripheralSpecDelegate {
     ///   - data: The data written.
     func peripheral(_ peripheral: CBMPeripheralSpec,
                     didReceiveWriteCommandFor characteristic: CBMCharacteristicMock,
-                    data: Data)
-    
-    @available(*, deprecated, message: "Use similar method with CBMCharacteristicMock parameter type.")
-    func peripheral(_ peripheral: CBMPeripheralSpec,
-                    didReceiveWriteCommandFor characteristic: CBMCharacteristic,
                     data: Data)
 
     /// This method will be called when write request has been initiated from a mock
@@ -200,12 +161,6 @@ public protocol CBMPeripheralSpecDelegate {
     ///            returned to the ``CBMPeripheralDelegate/peripheral(_:didWriteValueFor:error:)-90cp``.
     func peripheral(_ peripheral: CBMPeripheralSpec,
                     didReceiveWriteRequestFor descriptor: CBMDescriptorMock,
-                    data: Data)
-        -> Result<Void, Error>
-    
-    @available(*, deprecated, message: "Use similar method with CBMDescriptorMock parameter type.")
-    func peripheral(_ peripheral: CBMPeripheralSpec,
-                    didReceiveWriteRequestFor descriptor: CBMDescriptor,
                     data: Data)
         -> Result<Void, Error>
 
@@ -224,12 +179,6 @@ public protocol CBMPeripheralSpecDelegate {
     func peripheral(_ peripheral: CBMPeripheralSpec,
                     didReceiveSetNotifyRequest enabled: Bool,
                     for characteristic: CBMCharacteristicMock)
-        -> Result<Void, Error>
-    
-    @available(*, deprecated, message: "Use similar method with CBMCharacteristicMock parameter type.")
-    func peripheral(_ peripheral: CBMPeripheralSpec,
-                    didReceiveSetNotifyRequest enabled: Bool,
-                    for characteristic: CBMCharacteristic)
         -> Result<Void, Error>
   
     /// This method will be called when notifications or indications were enabled
@@ -271,21 +220,7 @@ public extension CBMPeripheralSpecDelegate {
     
     func peripheral(_ peripheral: CBMPeripheralSpec,
                     didReceiveIncludedServiceDiscoveryRequest serviceUUIDs: [CBMUUID]?,
-                    for service: CBMService)
-        -> Result<Void, Error> {
-            return .success(())
-    }
-    
-    func peripheral(_ peripheral: CBMPeripheralSpec,
-                    didReceiveIncludedServiceDiscoveryRequest serviceUUIDs: [CBMUUID]?,
                     for service: CBMServiceMock)
-        -> Result<Void, Error> {
-            return self.peripheral(peripheral, didReceiveIncludedServiceDiscoveryRequest: serviceUUIDs, for: service as CBMService)
-    }
-    
-    func peripheral(_ peripheral: CBMPeripheralSpec,
-                    didReceiveCharacteristicsDiscoveryRequest characteristicUUIDs: [CBMUUID]?,
-                    for service: CBMService)
         -> Result<Void, Error> {
             return .success(())
     }
@@ -293,12 +228,6 @@ public extension CBMPeripheralSpecDelegate {
     func peripheral(_ peripheral: CBMPeripheralSpec,
                     didReceiveCharacteristicsDiscoveryRequest characteristicUUIDs: [CBMUUID]?,
                     for service: CBMServiceMock)
-        -> Result<Void, Error> {
-            return self.peripheral(peripheral, didReceiveCharacteristicsDiscoveryRequest: characteristicUUIDs, for: service as CBMService)
-    }
-    
-    func peripheral(_ peripheral: CBMPeripheralSpec,
-                    didReceiveDescriptorsDiscoveryRequestFor characteristic: CBMCharacteristic)
         -> Result<Void, Error> {
             return .success(())
     }
@@ -306,23 +235,11 @@ public extension CBMPeripheralSpecDelegate {
     func peripheral(_ peripheral: CBMPeripheralSpec,
                     didReceiveDescriptorsDiscoveryRequestFor characteristic: CBMCharacteristicMock)
         -> Result<Void, Error> {
-            return self.peripheral(peripheral, didReceiveDescriptorsDiscoveryRequestFor: characteristic as CBMCharacteristic)
-    }
-    
-    func peripheral(_ peripheral: CBMPeripheralSpec,
-                    didReceiveReadRequestFor characteristic: CBMCharacteristic)
-        -> Result<Data, Error> {
-            return .failure(CBMATTError(.readNotPermitted))
+            return .success(())
     }
     
     func peripheral(_ peripheral: CBMPeripheralSpec,
                     didReceiveReadRequestFor characteristic: CBMCharacteristicMock)
-        -> Result<Data, Error> {
-            return self.peripheral(peripheral, didReceiveReadRequestFor: characteristic as CBMCharacteristic)
-    }
-    
-    func peripheral(_ peripheral: CBMPeripheralSpec,
-                    didReceiveReadRequestFor descriptor: CBMDescriptor)
         -> Result<Data, Error> {
             return .failure(CBMATTError(.readNotPermitted))
     }
@@ -330,52 +247,32 @@ public extension CBMPeripheralSpecDelegate {
     func peripheral(_ peripheral: CBMPeripheralSpec,
                     didReceiveReadRequestFor descriptor: CBMDescriptorMock)
         -> Result<Data, Error> {
-            return self.peripheral(peripheral, didReceiveReadRequestFor: descriptor as CBMDescriptor)
-    }
-    
-    func peripheral(_ peripheral: CBMPeripheralSpec,
-                    didReceiveWriteRequestFor characteristic: CBMCharacteristic,
-                    data: Data)
-        -> Result<Void, Error> {
-            return .failure(CBMATTError(.writeNotPermitted))
+            return .failure(CBMATTError(.readNotPermitted))
     }
     
     func peripheral(_ peripheral: CBMPeripheralSpec,
                     didReceiveWriteRequestFor characteristic: CBMCharacteristicMock,
                     data: Data)
         -> Result<Void, Error> {
-            return self.peripheral(peripheral, didReceiveWriteRequestFor: characteristic as CBMCharacteristic, data: data)
-    }
-    
-    func peripheral(_ peripheral: CBMPeripheralSpec,
-                    didReceiveWriteCommandFor characteristic: CBMCharacteristic,
-                    data: Data) {
-        // Empty default implementation
+            return .failure(CBMATTError(.writeNotPermitted))
     }
     
     func peripheral(_ peripheral: CBMPeripheralSpec,
                     didReceiveWriteCommandFor characteristic: CBMCharacteristicMock,
                     data: Data) {
-        self.peripheral(peripheral, didReceiveWriteCommandFor: characteristic as CBMCharacteristic, data: data)
-    }
-    
-    func peripheral(_ peripheral: CBMPeripheralSpec,
-                    didReceiveWriteRequestFor descriptor: CBMDescriptor,
-                    data: Data)
-        -> Result<Void, Error> {
-            return .failure(CBATTError(.writeNotPermitted))
+        // Empty default implementation
     }
     
     func peripheral(_ peripheral: CBMPeripheralSpec,
                     didReceiveWriteRequestFor descriptor: CBMDescriptorMock,
                     data: Data)
         -> Result<Void, Error> {
-            return self.peripheral(peripheral, didReceiveWriteRequestFor: descriptor as CBMDescriptor, data: data)
+            return .failure(CBATTError(.writeNotPermitted))
     }
     
     func peripheral(_ peripheral: CBMPeripheralSpec,
                     didReceiveSetNotifyRequest enabled: Bool,
-                    for characteristic: CBMCharacteristic)
+                    for characteristic: CBMCharacteristicMock)
         -> Result<Void, Error> {
             if !characteristic.properties
                 .isDisjoint(with: [
@@ -387,13 +284,6 @@ public extension CBMPeripheralSpecDelegate {
             } else {
                 return .failure(CBMError(.invalidHandle))
             }
-    }
-    
-    func peripheral(_ peripheral: CBMPeripheralSpec,
-                    didReceiveSetNotifyRequest enabled: Bool,
-                    for characteristic: CBMCharacteristicMock)
-        -> Result<Void, Error> {
-            return self.peripheral(peripheral, didReceiveSetNotifyRequest: enabled, for: characteristic as CBMCharacteristic)
     }
   
     func peripheral(_ peripheral: CBMPeripheralSpec,

--- a/CoreBluetoothMock/Documentation.docc/CBMPeripheralSpec.md
+++ b/CoreBluetoothMock/Documentation.docc/CBMPeripheralSpec.md
@@ -47,9 +47,3 @@ like the ``CBMCentralManagerNative`` can interact with real devices.
 - ``isKnown``
 - ``services``
 
-### Deprecated
-
-- ``advertisementData``
-- ``advertisingInterval``
-- ``isAdvertisingWhenConnected``
-

--- a/CoreBluetoothMock/Documentation.docc/CBMPeripheralSpecDelegate.md
+++ b/CoreBluetoothMock/Documentation.docc/CBMPeripheralSpecDelegate.md
@@ -30,15 +30,3 @@ The default implementation will successfully return all requested attributes. Th
 - ``peripheral(_:didReceiveSetNotifyRequest:for:)-9r03q``
 - ``peripheral(_:didUpdateNotificationStateFor:error:)-4aash``
 
-### Deprecated
-
-- ``peripheral(_:didReceiveIncludedServiceDiscoveryRequest:for:)-4g4y5``
-- ``peripheral(_:didReceiveCharacteristicsDiscoveryRequest:for:)-88ij9``
-- ``peripheral(_:didReceiveDescriptorsDiscoveryRequestFor:)-3y8of``
-- ``peripheral(_:didReceiveReadRequestFor:)-47a2c``
-- ``peripheral(_:didReceiveReadRequestFor:)-6p4xw``
-- ``peripheral(_:didReceiveWriteCommandFor:data:)-14ln0``
-- ``peripheral(_:didReceiveWriteRequestFor:data:)-3nc1b``
-- ``peripheral(_:didReceiveWriteRequestFor:data:)-6plt7``
-- ``peripheral(_:didReceiveSetNotifyRequest:for:)-8yagc``
-


### PR DESCRIPTION
As we're preparing for 1.0.0 release, this PR removes all deprecated methods and properties that are a part of this library.
All deprecated fields that are emulated as native API are intact.

Time to migrate if you still didn't!