### PR TITLE
Bug fix: remove services upon disconnect even if reconnecting

### DIFF
--- a/CoreBluetoothMock/CBMCentralManagerNative.swift
+++ b/CoreBluetoothMock/CBMCentralManagerNative.swift
@@ -169,9 +169,8 @@ public class CBMCentralManagerNative: CBMCentralManager {
                             isReconnecting: Bool,
                             error: (any Error)?) {
             let p = getPeripheral(peripheral)
-            if !isReconnecting {
-                p.mockServices = nil
-            }
+            p.mockServices = nil
+            
             manager.delegate?.centralManager(manager,
                                              didDisconnectPeripheral: p,
                                              timestamp: timestamp,


### PR DESCRIPTION
This pull request addresses #150. Invalidated services were remaining in memory and ultimately being duplicated when a device reconnects after disconnecting. This occurs for devices that were connected with `CBConnectPeripheralOptionsEnableAutoReconnect` set to `true`.