### PR TITLE
Check characteristics array when initializing CBMServiceNative

### DIFF
--- a/CoreBluetoothMock/CBMAttributes.swift
+++ b/CoreBluetoothMock/CBMAttributes.swift
@@ -122,7 +122,8 @@ internal class CBMServiceNative: CBMService {
         self.peripheral = peripheral
         self.isPrimary = service.isPrimary
                 
-        if let nativeCharacteristics = service.characteristics {
+        let nativeCharacteristics = safeCharacteristics(of: service)
+        if !nativeCharacteristics.isEmpty {
             _characteristics = nativeCharacteristics.map { CBMCharacteristicNative($0, in: self) }
         }
         


### PR DESCRIPTION
This is a proposed fix for #153. The crash reports an error: `Fatal error: NSArray element failed to match the Swift Array Element type Expected CBCharacteristic but found CBService`