### PR TITLE
Check peripheral identity to avoid using a stale instance

### DIFF
--- a/CoreBluetoothMock/CBMCentralManagerNative.swift
+++ b/CoreBluetoothMock/CBMCentralManagerNative.swift
@@ -125,7 +125,16 @@ public class CBMCentralManagerNative: CBMCentralManager {
         #endif
         
         fileprivate func getPeripheral(_ peripheral: CBPeripheral) -> CBMPeripheralNative {
-            return manager.peripherals[peripheral.identifier] ?? newPeripheral(peripheral)
+            guard let cachedPeripheral = manager.peripherals[peripheral.identifier] else {
+                return newPeripheral(peripheral)
+            }
+
+            // CBPeripheral may be a different instance with the same identifier
+            guard cachedPeripheral.peripheral === peripheral else {
+                return newPeripheral(peripheral)
+            }
+
+            return cachedPeripheral
         }
         
         private func newPeripheral(_ peripheral: CBPeripheral) -> CBMPeripheralNative {


### PR DESCRIPTION
Hi, this is proposed fix for #155. 

This just checks if the cached CBMPeripheralNative has the same CBPeripheral object and updates the cache if the peripheral has changed.