### PR TITLE
Fix included-services match/update predicate in CBMServiceNative.update(_:)

### DIFF
--- a/CoreBluetoothMock/CBMAttributes.swift
+++ b/CoreBluetoothMock/CBMAttributes.swift
@@ -139,8 +139,8 @@ internal class CBMServiceNative: CBMService {
     func update(_ service: CBService) {
         for includedService in service.includedServices ?? [] {
             if _includedServices == nil { _includedServices = [] }
-            if let existing = (_includedServices as? [CBMServiceNative])?.first(where: { $0.service == service }) {
-                existing.update(service)
+            if let existing = (_includedServices as? [CBMServiceNative])?.first(where: { $0.service == includedService }) {
+                existing.update(includedService)
             } else {
                 let newService = CBMServiceNative(includedService, in: peripheral!)
                 _includedServices!.append(newService)


### PR DESCRIPTION
**The bug (found by Copilot and confirmed by Claude when I was porting the latest changes to my internal codebase):**

In CBMServiceNative.update(_:) (introduced in https://github.com/nordicsemi/IOS-CoreBluetooth-Mock/pull/138), the included-services merge loop iterates over service.includedServices, but both the lookup predicate and the recursive update() call reference the parent service instead of the iterated includedService:

```
for includedService in service.includedServices ?? [] {
    if let existing = (...).first(where: { $0.service == service }) {   // ← parent, should be includedService
        existing.update(service)                                          // ← parent, should be includedService
    } else {
        let newService = CBMServiceNative(includedService, in: peripheral!)
        _includedServices!.append(newService)
    }
}
```

**Issue**

A parent CBService is never present in its own children's _includedServices list in any real BLE service tree, so first(where: { $0.service == service }) never matches. Every iteration falls through to the else branch and appends a new CBMServiceNative wrapper. On repeated calls to update(_:) (which is the whole point of the smart-copy refactor in #138 — keep wrappers stable across re-discovery), the included-services list grows by one duplicate wrapper per included service per call. The recursive existing.update(service) is also unreachable, but if it ever were reached it would update a child wrapper with its parent's CBService, which is incorrect.

**The fix**

Use the loop variable in both places:

```
if let existing = (...).first(where: { $0.service == includedService }) {
    existing.update(includedService)
} else { ... }
```

This mirrors the structurally-correct loop just below it (for characteristic in safeCharacteristics(of: service) → match/update on characteristic), and the descriptor loop in CBMCharacteristicNative.update(_:).

**Impact / how it was found**

The buggy branch only fires when a consumer calls peripheral.discoverIncludedServices(_:for:) and then re-discovers in a way that retriggers update(_:). Most consumers — including ours — don't exercise BLE Included Services at all, which is presumably why the bug wasn't caught by tests. Originally flagged by GitHub Copilot during review of our internal port of the 1.0.x fixes; we patched it locally.
