### PR TITLE
Blinky Spec customization

### DIFF
--- a/CoreBluetoothMock/Specs/Blinky.swift
+++ b/CoreBluetoothMock/Specs/Blinky.swift
@@ -33,62 +33,216 @@ import Combine
 
 // MARK: - Blinky
 
+/// A delegate protocol for receiving updates from the `Blinky` peripheral.
+public protocol BlinkyDelegate: AnyObject {
+    
+    /// Notifies the delegate that the connected central requested LED state change on the specified Blinky peripheral.
+    ///
+    /// - Parameters:
+    ///   - blinky: The `Blinky` instance.
+    ///   - isOn: A Boolean value indicating the new state of the LED. `true` if the LED is on; otherwise, `false`.
+    func blinky(_ blinky: Blinky, didChangeLedState isOn: Bool)
+    
+    /// Notifies the delegate that the subscription state for the button characteristic has changed.
+    ///
+    /// - Parameters:
+    ///   - blinky: The `Blinky` instance.
+    ///   - isSubscribed: A Boolean value indicating whether a client is now subscribed to button state changes.
+    func blinky(_ blinky: Blinky, didChangeButtonSubscriptionState isSubscribed: Bool)
+}
+
+/// A sample ``BlinkyDelegate`` that will periodically simulate button presses when a client is
+/// subscribed to button notifications.
+public class PeriodicBlinkyDelegate: BlinkyDelegate {
+    /// The timer used to schedule periodic simulated button presses. Kept `nil` when not active.
+    private var timer: DispatchSourceTimer?
+
+    /// An period of time between simulated button presses.
+    ///
+    /// Defaults to 1 second.
+    private let period: TimeInterval
+    /// The time the button will be in *pressed* state.
+    private let pressedDuration: TimeInterval
+    
+    /// Creates a periodic, simulated Blinky delegate that will "press" the button at a fixed cadence
+    /// whenever a client is subscribed to button notifications.
+    ///
+    /// - Parameters:
+    ///   - releasedDuration: The duration, in seconds, that the simulated button remains in the "released".
+    ///                       Defaults to 1 second.
+    ///   - pressedDuration: The duration, in seconds, that the simulated button remains in the "pressed"
+    ///                      Defaults to 250 ms.
+    public init(releasedDuration: TimeInterval = 1.0,
+                pressedDuration: TimeInterval = 0.250) {
+        self.period = releasedDuration + pressedDuration
+        self.pressedDuration = pressedDuration
+    }
+    
+    public func blinky(_ blinky: Blinky, didChangeLedState isOn: Bool) {
+        // No Op.
+    }
+    
+    public func blinky(_ blinky: Blinky, didChangeButtonSubscriptionState isSubscribed: Bool) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            if isSubscribed {
+                self.startTimer(for: blinky)
+            } else {
+                self.stopTimer()
+            }
+        }
+    }
+    
+    private func startTimer(for blinky: Blinky) {
+        // If a timer is already active, do nothing to avoid duplicate schedules.
+        guard timer == nil else { return }
+
+        let t = DispatchSource.makeTimerSource(queue: DispatchQueue.main)
+        // First fire after `period`, then repeat every `period`.
+        t.schedule(deadline: .now() + period, repeating: period)
+        t.setEventHandler { [weak self, weak blinky] in
+            guard let self = self, let blinky = blinky, self.timer != nil else { return }
+            // Simulate button press.
+            blinky.simulateButtonToggle()
+            // Schedule release after pressDuration.
+            DispatchQueue.main.asyncAfter(deadline: .now() + self.pressedDuration) { [weak self, weak blinky] in
+                guard let self = self, let blinky = blinky, self.timer != nil else { return }
+                blinky.simulateButtonToggle()
+            }
+        }
+        self.timer = t
+        t.resume()
+    }
+    
+    private func stopTimer() {
+        guard let t = timer else { return }
+        t.setEventHandler {}
+        t.cancel()
+        timer = nil
+    }
+}
+
+/// A sample implementation of a mock peripheral with Nordic LED Button Service (LBS), also known as *Blinky*.
+///
+/// A connected client can send requests to turn the LED on or OFF, and subscribe to button state notifications.
+///
+/// The `Blinky` object provides methods to simulate button toggles and peripheral resets, which can be used in tests.
+///
+/// The instance begins advertising the LED Button Service (UUID 00001523-1212-EFDE-1523-785FEABCD123) as connectable,
+/// with a 250 ms advertising interval.
+/// When connected, it exposes:
+///   - Button characteristic (notify + read): sends notifications on simulated button toggles.
+///   - LED characteristic (write + read): accepts writes to change LED state and notifies the delegate.
+///
+/// Use ``Blinky/simulateButtonToggle()`` to simulate a Button press on the DK, which will send a
+/// notification to the connected client, and ``Blinky/simulateReset()`` to simulate a peripheral reset,
+/// which will reset the LED state to the initial value and terminate existing connection.
+///
+/// - seeAlso: ``simulateButtonToggle()``, ``simulateReset()``, ``BlinkyDelegate``
 public class Blinky {
+    public static let serviceUUID = CBMUUID.ledButtonService
+    
+    /// The peripheral specification that defines the behavior of this Blinky peripheral.
+    public let spec: CBMPeripheralSpec
     
     // MARK: Private Properties
     
+    /// The name of the peripheral, used in the advertisement data and as a local name when connected.
     private let name: String
-    private var ledEnabled: Bool
-    private var buttonPressed: Bool
-    private var recurringTimer: Bool
-    
-    private var ledData: Data {
-        return ledEnabled ? Data([0x01]) : Data([0x00])
-    }
-    private var buttonData: Data {
-        return buttonPressed ? Data([0x01]) : Data([0x00])
-    }
+    /// The implementation of the Blinky peripheral's behavior, handling read/write requests and notifications.
+    private let impl: BlinkyImpl
     
     // MARK: init
     
-    public init(name: String = "Nordic_Blinky") {
-        self.ledEnabled = false
-        self.buttonPressed = false
-        self.recurringTimer = false
+    /// Initializes a mock peripheral with Nordic LED Button Service (LBS), also known as *Blinky*.
+    ///
+    /// - Parameters:
+    ///   - identifier: The stable, unique identifier for the simulated peripheral.
+    ///                 Provide a fixed value to keep the same identity across app launches (default: a new UUID()).
+    ///   - name: The local name used in advertising and when connected. Defaults to "Nordic_Blinky".
+    ///   - proximity: The simulated proximity used by CoreBluetoothMock to influence RSSI and discovery behavior.
+    ///                Defaults to `.immediate`.
+    ///   - delegate: An optional delegate receiving LED state updates and button subscription changes.
+    ///               The delegate is not retained.
+    ///
+    /// - seeAlso: ``PeriodicBlinkyDelegate``
+    public init(identifier: UUID = UUID(),
+                name: String = "Nordic_Blinky",
+                proximity: CBMProximity = .immediate,
+                delegate: BlinkyDelegate? = nil) {
         self.name = name
+        self.impl = BlinkyImpl()
+        self.spec = CBMPeripheralSpec
+            .simulatePeripheral(identifier: identifier, proximity: proximity)
+            .advertising(
+                advertisementData: [
+                    CBMAdvertisementDataIsConnectable : true as NSNumber,
+                    CBMAdvertisementDataLocalNameKey : name,
+                    CBMAdvertisementDataServiceUUIDsKey : [CBMUUID.ledButtonService]
+                ],
+                withInterval: 0.250, // sec
+                delay: 0, // sec
+                alsoWhenConnected: false
+            )
+            .connectable(
+                name: name,
+                services: [.blinkyService],
+                delegate: impl,
+                connectionInterval: 0.02,
+            )
+            .build()
+        
+        // Handle state changes.
+        weak let userDelegate = delegate
+        impl.ledStateDidChange = { [weak self, userDelegate] isOn in
+            DispatchQueue.main.async { [weak self, userDelegate] in
+                guard let self = self else { return }
+                userDelegate?.blinky(self, didChangeLedState: isOn)
+            }
+        }
+        impl.buttonSubscriptionStateDidChange = { [weak self, userDelegate] isSubscribed in
+            DispatchQueue.main.async { [weak self, userDelegate] in
+                guard let self = self else { return }
+                userDelegate?.blinky(self, didChangeButtonSubscriptionState: isSubscribed)
+            }
+        }
     }
     
-    public private(set) lazy var spec = CBMPeripheralSpec
-        .simulatePeripheral(proximity: .immediate)
-        .advertising(
-            advertisementData: [
-                CBMAdvertisementDataIsConnectable : true as NSNumber,
-                CBMAdvertisementDataLocalNameKey : name,
-                CBMAdvertisementDataServiceUUIDsKey : [CBMUUID.blinkyService]
-            ],
-            withInterval: 2.0,
-            delay: 5.0,
-            alsoWhenConnected: false
-        )
-        .connectable(
-            name: name,
-            services: [.blinkyService],
-            delegate: self,
-            connectionInterval: 0.02,
-        )
-        .build()
+    /// Simulates a button toggle.
+    ///
+    /// This will send a notification to the subscribed client.
+    public func simulateButtonToggle() {
+        impl.isButtonPressed.toggle()
+        spec.simulateValueUpdate(impl.isButtonPressed.data, for: .buttonCharacteristic)
+    }
+    
+    /// Simulates a peripheral reset, which will disconnect all connected centrals and stop advertising.
+    public func simulateReset() {
+        spec.simulateReset()
+    }
 }
 
 // MARK: - CBMPeripheralSpecDelegate
 
-extension Blinky: CBMPeripheralSpecDelegate {
+private class BlinkyImpl: CBMPeripheralSpecDelegate {
     
-    public func peripheral(_ peripheral: CBMPeripheralSpec, didReceiveReadRequestFor characteristic: CBMCharacteristicMock) -> Result<Data, Error> {
+    // MARK: Properties
+    
+    var ledStateDidChange: ((Bool) -> ())!
+    var buttonSubscriptionStateDidChange: ((Bool) -> ())!
+    
+    var isLedOn: Bool = false
+    var isButtonPressed: Bool = false
+    
+    // MARK: CBMPeripheralSpecDelegate
+    
+    public func peripheral(_ peripheral: CBMPeripheralSpec,
+                           didReceiveReadRequestFor characteristic: CBMCharacteristicMock) -> Result<Data, Error> {
         switch characteristic.uuid {
         case .buttonCharacteristic:
-            return .success(buttonData)
+            return .success(isButtonPressed.data)
         case .ledCharacteristic:
-            return .success(ledData)
+            return .success(isLedOn.data)
         default:
             return .failure(CBMATTError(.readNotPermitted))
         }
@@ -99,58 +253,73 @@ extension Blinky: CBMPeripheralSpecDelegate {
                            data: Data) -> Result<Void, Error> {
         switch characteristic.uuid {
         case .ledCharacteristic:
-            ledEnabled = data[0] != 0x00
+            isLedOn = data.bool
+            ledStateDidChange(isLedOn)
             return .success(())
         default:
             return .failure(CBMATTError(.writeNotPermitted))
         }
     }
     
-    public func peripheral(_ peripheral: CBMPeripheralSpec, didReceiveSetNotifyRequest enabled: Bool, for characteristic: CBMCharacteristicMock) -> Result<Void, Error> {
+    public func peripheral(_ peripheral: CBMPeripheralSpec,
+                           didReceiveSetNotifyRequest enabled: Bool,
+                           for characteristic: CBMCharacteristicMock) -> Result<Void, Error> {
         switch characteristic.uuid {
         case .buttonCharacteristic:
-            updateSimulation(peripheral, characteristic: characteristic, enabled: enabled)
+            buttonSubscriptionStateDidChange(enabled)
             return .success(())
         default:
             return .failure(CBMATTError(.requestNotSupported))
         }
     }
     
-    public func peripheral(_ peripheral: CBMPeripheralSpec, didDisconnect error: (any Error)?) {
-        reset()
+    public func peripheral(_ peripheral: CBMPeripheralSpec,
+                           didDisconnect error: Error?) {
+        buttonSubscriptionStateDidChange(false)
     }
     
-    public func reset() {
-        ledEnabled = false
-        buttonPressed = false
-        recurringTimer = false
+    func reset() {
+        isLedOn = false
+        // Note: The button state is not reset, as this depends on the mock
+        //       button actually being pressed. Resetting a DK does not make
+        //       the button "unpressed" if it was in a pressed state at the time of reset.
+        
+        print("""
+        ----------------------------------------
+        *** Booting Mock LBS sample v2.0 ***
+        Starting Bluetooth Peripheral LBS sample
+        Bluetooth initialized
+        Advertising successfully started
+        ----------------------------------------
+        """)
     }
 }
 
-// MARK: Private
+// MARK: - Helper Extensions
 
-private extension Blinky {
+private extension Bool {
     
-    func updateSimulation(_ peripheral: CBMPeripheralSpec, characteristic: CBMCharacteristicMock, enabled: Bool) {
-        recurringTimer = enabled
-        guard enabled else { return }
-        enqueueSimulatedButtonPress(peripheral, characteristic: characteristic)
+    /// Converts the Boolean value to `Data` using the LBS specification.
+    var data: Data {
+        return Data([self ? 0x01 : 0x00])
     }
     
-    func enqueueSimulatedButtonPress(_ peripheral: CBMPeripheralSpec, characteristic: CBMCharacteristicMock) {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
-            guard let self, recurringTimer else { return }
-            buttonPressed = !buttonPressed
-            peripheral.simulateValueUpdate(buttonData, for: characteristic)
-            enqueueSimulatedButtonPress(peripheral, characteristic: characteristic)
-        }
+}
+
+private extension Data {
+    
+    /// Converts the `Data` to a Boolean value using the LBS specification.
+    var bool: Bool {
+        guard self.count == 1 else { return false }
+        return self[0] != 0x00
     }
+    
 }
 
 // MARK: - CoreBluetoothMock
 
 private extension CBMUUID {
-    static let blinkyService: CBMUUID! = CBMUUID(string: "00001523-1212-EFDE-1523-785FEABCD123")
+    static let ledButtonService: CBMUUID! = CBMUUID(string: "00001523-1212-EFDE-1523-785FEABCD123")
     
     static let buttonCharacteristic: CBMUUID! = CBMUUID(string: "00001524-1212-EFDE-1523-785FEABCD123")
     static let ledCharacteristic: CBMUUID! = CBMUUID(string: "00001525-1212-EFDE-1523-785FEABCD123")
@@ -159,10 +328,11 @@ private extension CBMUUID {
 private extension CBMServiceMock {
     
     static let blinkyService = CBMServiceMock(
-        type: .blinkyService,
+        type: .ledButtonService,
         primary: true,
         characteristics: .buttonCharacteristic, .ledCharacteristic
     )
+    
 }
 
 private extension CBMCharacteristicMock {
@@ -177,4 +347,6 @@ private extension CBMCharacteristicMock {
         type: .ledCharacteristic,
         properties: [.write, .read]
     )
+    
 }
+

--- a/Example/nRFBlinky/AppDelegate.swift
+++ b/Example/nRFBlinky/AppDelegate.swift
@@ -70,7 +70,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                     return [
                         // When the app was killed it was scanning with the LBS Service UUID filter.
                         CBMCentralManagerRestoredStateScanServicesKey: [
-                            CBMUUID.nordicBlinkyService
+                            Blinky.serviceUUID
                         ],
                         // Also, the app was scanning with the "Allow Duplicates" option enabled.
                         CBMCentralManagerRestoredStateScanOptionsKey: [

--- a/Example/nRFBlinky/MockPeripherals.swift
+++ b/Example/nRFBlinky/MockPeripherals.swift
@@ -33,109 +33,32 @@ import CoreBluetoothMock
 
 // MARK: - Mock nRF Blinky
 
-extension CBMUUID {
-    static let nordicBlinkyService  = CBMUUID(string: "00001523-1212-EFDE-1523-785FEABCD123")
-    static let buttonCharacteristic = CBMUUID(string: "00001524-1212-EFDE-1523-785FEABCD123")
-    static let ledCharacteristic    = CBMUUID(string: "00001525-1212-EFDE-1523-785FEABCD123")
-}
+/// A wrapper around the Blinky peripheral spec, that allows simulating button clicks
+/// or providing high-level behavior.
+///
+/// This is how you may simulate Button click using a mock Blinky:
+///
+/// ```swift
+/// blinkyImpl.simulateButtonToggle()
+/// ```
+private let blinkyImpl = Blinky(
+//    identifier: UUID(),
+//    name: "Nordic_Blinky",
+//    proximity: .immediate,
+//    delegate: PeriodicBlinkyDelegate(
+//        releasedDuration: 2,
+//        pressedDuration: 0.5,
+//    )
+)
 
-extension CBMCharacteristicMock {
-    
-    static let buttonCharacteristic = CBMCharacteristicMock(
-        type: .buttonCharacteristic,
-        properties: [.notify, .read],
-        descriptors: CBMClientCharacteristicConfigurationDescriptorMock()
-    )
-
-    static let ledCharacteristic = CBMCharacteristicMock(
-        type: .ledCharacteristic,
-        properties: [.write, .read]
-    )
-    
-}
-
-extension CBMServiceMock {
-
-    static let blinkyService = CBMServiceMock(
-        type: .nordicBlinkyService, primary: true,
-        characteristics:
-            .buttonCharacteristic,
-            .ledCharacteristic
-    )
-    
-}
-
-private class BlinkyCBMPeripheralSpecDelegate: CBMPeripheralSpecDelegate {
-    private var ledEnabled: Bool = false
-    private var buttonPressed: Bool = false
-    
-    private var ledData: Data {
-        return ledEnabled ? Data([0x01]) : Data([0x00])
-    }
-    
-    private var buttonData: Data {
-        return buttonPressed ? Data([0x01]) : Data([0x00])
-    }
-
-    func reset() {
-        ledEnabled = false
-        buttonPressed = false
-        print("""
-        ----------------------------------------
-        *** Booting Mock LBS sample v1.0 ***
-        Starting Bluetooth Peripheral LBS sample
-        Bluetooth initialized
-        Advertising successfully started
-        ----------------------------------------
-        """)
-    }
-
-    func peripheral(_ peripheral: CBMPeripheralSpec,
-                    didReceiveReadRequestFor characteristic: CBMCharacteristicMock)
-            -> Result<Data, Error> {
-        if characteristic.uuid == .ledCharacteristic {
-            return .success(ledData)
-        } else {
-            return .success(buttonData)
-        }
-    }
-    
-    func peripheral(_ peripheral: CBMPeripheralSpec,
-                    didReceiveWriteRequestFor characteristic: CBMCharacteristicMock,
-                    data: Data) -> Result<Void, Error> {
-        if data.count > 0 {
-            ledEnabled = data[0] != 0x00
-        }
-        return .success(())
-    }
-    
-    func peripheral(_ peripheral: CBMPeripheralSpec, didDisconnect error: (any Error)?) {
-        print("Central disconnected with error: \(error?.localizedDescription ?? "none")")
-    }
-}
-
-let blinky = CBMPeripheralSpec
-    .simulatePeripheral(proximity: .outOfRange)
-    .advertising(
-        advertisementData: [
-            CBMAdvertisementDataLocalNameKey    : "nRF Blinky",
-            CBMAdvertisementDataServiceUUIDsKey : [CBMUUID.nordicBlinkyService],
-            CBMAdvertisementDataIsConnectable   : true as NSNumber
-        ],
-        withInterval: 0.250,
-        alsoWhenConnected: false)
-    .connectable(
-        name: "nRF Blinky",
-        services: [.blinkyService],
-        delegate: BlinkyCBMPeripheralSpecDelegate(),
-        connectionInterval: 0.150,
-        supervisionTimeout: 0,
-        mtu: 23)
-    .build()
-
-// This is how you may simulate Button click using a mock Blinky:
-//
-// blinky.simulateValueUpdate(Data([0x01]), for: .buttonCharacteristic)
+/// The *Blinky* spec peripheral is used for mock Central Manager.
+///
+/// This is how you may simulate Button click using a mock Blinky:
+///
+/// ```swift
+/// blinky.simulateValueUpdate(Data([0x01]), for: .buttonCharacteristic)
+/// ```
+let blinky = blinkyImpl.spec
 
 // MARK: - Mock Nordic HRM
 


### PR DESCRIPTION
This PR adds a bit of more flexibility to the sample `Blinky` spec, added in #165.

It also replaces the mock implementation in `MockPeripherals.swift` to use the one from the library. 